### PR TITLE
Add support for namespaces

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -66,7 +66,7 @@
     "crc-kit": "func() { node tasks/cli/index.js  create-component --name=\"$1\" --path=./src/components/kit/ --lint; }; func",
     "crc": "func() { node tasks/cli/index.js  create-component --name=\"$1\" --path=./src/components/ --lint; }; func"
   },
-  "homepage": "/aim/static-files/",
+  "homepage": "/static/aim/",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -208,7 +208,10 @@
       })();
     </script>
     <script>
-      window.API_BASE_PATH = '/aim';
+      const found = window.location.pathname.match(/^(\/ns\/[^/]+\/)aim/);
+      const prefix = found ? found[1] : '/';
+      window.PREFIX = prefix;
+      window.API_BASE_PATH = prefix + 'aim';
       window.externalPublicPath = '%PUBLIC_URL%/';
     </script>
   </head>

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -27,7 +27,7 @@ const isVisibleCacheBanner = checkIsBasePathInCachedEnv(basePath) && inIframe();
 // loading monaco from node modules instead of CDN
 loader.config({
   paths: {
-    vs: `${getBasePath()}/static-files/vs`,
+    vs: '/static/aim/vs',
   },
 });
 

--- a/src/src/components/SideBar/SideBar.tsx
+++ b/src/src/components/SideBar/SideBar.tsx
@@ -10,7 +10,7 @@ import { IconName } from 'components/kit/Icon';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
 import { PathEnum } from 'config/enums/routesEnum';
-import { getBaseHost } from 'config/config';
+import { getBaseHost, getPrefix } from 'config/config';
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 import { DOCUMENTATIONS } from 'config/references';
 
@@ -90,7 +90,7 @@ function SideBar(): React.FunctionComponentElement<React.ReactNode> {
           </ul>
           <div className='Sidebar__bottom'>
             <Tooltip title='Switch UI' placement='right'>
-              <a href='/' className='Sidebar__bottom__anchor'>
+              <a href={getPrefix()} className='Sidebar__bottom__anchor'>
                 <Icon name='live-demo' />
               </a>
             </Tooltip>

--- a/src/src/config/config.ts
+++ b/src/src/config/config.ts
@@ -2,6 +2,7 @@ import { version } from '../../package.json';
 
 interface GlobalScope extends Window {
   API_BASE_PATH?: string;
+  PREFIX?: string;
 }
 
 let globalScope: GlobalScope;
@@ -32,6 +33,19 @@ function getAPIHost() {
   return API_HOST;
 }
 
+function getPrefix(): string {
+  return `${globalScope.PREFIX}`;
+}
+
+function getTrackingURI(): string {
+  let host = getBaseHost();
+  if (host === '') {
+    const { protocol, hostname, port } = window.location;
+    host = `${protocol}//${hostname}${port ? `:${port}` : ''}`;
+  }
+  return `${host}${getPrefix()}`;
+}
+
 function setAPIBasePath(basePath: string) {
   globalScope.API_BASE_PATH = basePath;
   API_HOST = `${getBaseHost()}${getBasePath()}/api`;
@@ -48,4 +62,11 @@ export function checkIsBasePathInCachedEnv(basePath: string) {
   return PATHS_TO_SHOW_CACHE_BANNERS.includes(parsed_path);
 }
 
-export { getBaseHost, getBasePath, getAPIHost, setAPIBasePath };
+export {
+  getBaseHost,
+  getBasePath,
+  getAPIHost,
+  getPrefix,
+  getTrackingURI,
+  setAPIBasePath,
+};

--- a/src/src/pages/Dashboard/components/AimIntegrations/AimIntegrations.tsx
+++ b/src/src/pages/Dashboard/components/AimIntegrations/AimIntegrations.tsx
@@ -4,13 +4,12 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
-  Link,
 } from '@material-ui/core';
 
 import { Icon, Text } from 'components/kit';
 import CodeBlock from 'components/CodeBlock/CodeBlock';
 
-import { DOCUMENTATIONS } from 'config/references';
+import { getTrackingURI } from 'config/config';
 
 import './AimIntegrations.scss';
 
@@ -22,10 +21,6 @@ function AimIntegrations() {
       setExpanded(newExpanded ? panel : false);
     };
 
-  // Get fasttrack server hostname from current browser location
-  const { hostname, port, protocol } = window.location;
-  const fasttrack_server = `${protocol}//${hostname}:${port}`;
-
   const integrations = [
     {
       title: 'Integrate PyTorch Lightning',
@@ -33,7 +28,7 @@ function AimIntegrations() {
 import mlflow
 
 # Set FastTrackML tracking server
-mlflow.set_tracking_uri("${fasttrack_server}")
+mlflow.set_tracking_uri("${getTrackingURI()}")
 
 # Enable autologging
 mlflow.pytorch.autolog()
@@ -50,7 +45,7 @@ trainer.test()
 import mlflow
 
 # Set FastTrackML tracking server
-mlflow.set_tracking_uri("${fasttrack_server}")
+mlflow.set_tracking_uri("${getTrackingURI()}")
 
 # Enable autologging
 mlflow.tensorflow.autolog()
@@ -66,7 +61,7 @@ results = keras_model.fit(
 import xgboost as xgb
 
 # Set FastTrackML tracking server
-mlflow.set_tracking_uri("${fasttrack_server}")
+mlflow.set_tracking_uri("${getTrackingURI()}")
 
 # Enable autologging
 mlflow.xgboost.autolog()
@@ -83,7 +78,7 @@ with mlflow.start_run():
 import mlflow
 
 # Set FastTrackML tracking server
-mlflow.set_tracking_uri(${fasttrack_server})
+mlflow.set_tracking_uri(${getTrackingURI()})
 
 # Enable autologging
 mlflow.fastai.autolog()
@@ -105,7 +100,7 @@ with mlflow.start_run():
 import mlflow
 
 # Set FastTrackML tracking server
-mlflow.set_tracking_uri("${fasttrack_server}")
+mlflow.set_tracking_uri("${getTrackingURI()}")
 
 # Enable autologging
 mlflow.lightgbm.autolog()

--- a/src/src/pages/Dashboard/components/QuickStart/QuickStart.tsx
+++ b/src/src/pages/Dashboard/components/QuickStart/QuickStart.tsx
@@ -5,14 +5,12 @@ import { Link } from '@material-ui/core';
 import { Text } from 'components/kit';
 import CodeBlock from 'components/CodeBlock/CodeBlock';
 
+import { getTrackingURI } from 'config/config';
 import { DOCUMENTATIONS } from 'config/references';
 
 import './QuickStart.scss';
 
 function QuickStart() {
-  // Get fasttrack server hostname from current browser location
-  const { hostname, port, protocol } = window.location;
-  const fasttrack_server = `${protocol}//${hostname}:${port}`;
   return (
     <div className='QuickStart'>
       <Text
@@ -37,7 +35,7 @@ function QuickStart() {
           code={`import mlflow
 
 # Set FastTrackML tracking server
-mlflow.set_tracking_uri("${fasttrack_server}")
+mlflow.set_tracking_uri("${getTrackingURI()}")
 
 # Log parameters
 mlflow.log_params({


### PR DESCRIPTION
In order to support the major changes in https://github.com/G-Research/fasttrackml/pull/259, the Aim UI needs to be adapted to know how to call the correct namespaced API, to get its static files from a central location, and to properly compute the tracking URI for the quickstart snippets.