### PR TITLE
Preliminary ParamsScalePopover component

### DIFF
--- a/src/src/components/HighPlot/HighPlot.tsx
+++ b/src/src/components/HighPlot/HighPlot.tsx
@@ -45,6 +45,7 @@ const HighPlot = React.forwardRef(function HighPlot(
       bottom: 30,
       left: 60,
     },
+    scaleStates,
   } = props;
 
   // boxes
@@ -117,6 +118,7 @@ const HighPlot = React.forwardRef(function HighPlot(
       axesRef,
       dimensions: data.dimensions,
       plotBoxRef,
+      scaleStates,
     });
 
     if (attributesRef?.current.xScale && attributesRef.current.yScale) {

--- a/src/src/components/ParamsScalePopover/ParamsScalePopover.scss
+++ b/src/src/components/ParamsScalePopover/ParamsScalePopover.scss
@@ -1,0 +1,17 @@
+@use 'src/styles/abstracts' as *;
+
+.ParamsScalePopover {
+  width: 21.5rem;
+  padding: 1rem;
+
+  &__subtitle {
+    text-transform: uppercase;
+  }
+
+  &__select {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: $space-xs;
+  }
+}

--- a/src/src/components/ParamsScalePopover/ParamsScalePopover.tsx
+++ b/src/src/components/ParamsScalePopover/ParamsScalePopover.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { Text, ToggleButton } from 'components/kit';
+import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+
+import {
+  IParamsScalePopoverProps,
+  IParamsScaleStates,
+  IParamsScaleState
+} from 'types/components/ParamsScalePopover/ParamsScalePopover';
+
+import { ScaleEnum } from 'utils/d3';
+
+import './MetricsScalePopover.scss';
+
+function ParamsScalePopover(
+  props: IParamsScalePopoverProps,
+): React.FunctionComponentElement<React.ReactNode> {
+  function handleScaleChange(val: string | number, id: any) {
+    const scaleParams: IParamsScaleStates = {
+      ...props.paramsScaleType,
+      [id]: val,
+    };
+    props.onParamsScaleTypeChange(scaleParams);
+  }
+
+  return (
+    <ErrorBoundary>
+      <div className='ParamsScalePopover'>
+        <Text
+          size={12}
+          tint={50}
+          component='p'
+          className='ParamsScalePopover__subtitle'
+        >
+          Select Params Scale:
+        </Text>
+        {props.paramsScaleType.params.map((param: IParamsScaleState) => (
+          <div className='ParamsScalePopover__select'>
+            <ToggleButton
+              title={param.name + ' scale:'}
+              id={param.name}
+              value={param.scale}
+              leftValue={ScaleEnum.Linear}
+              rightValue={ScaleEnum.Log}
+              leftLabel='Linear'
+              rightLabel='Log'
+              onChange={handleScaleChange}
+            />
+          </div>
+        )) 
+        }
+      </div>
+    </ErrorBoundary>
+  );
+}
+
+export default React.memo(ParamsScalePopover);

--- a/src/src/components/ParamsScalePopover/ParamsScalePopover.tsx
+++ b/src/src/components/ParamsScalePopover/ParamsScalePopover.tsx
@@ -6,22 +6,25 @@ import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import {
   IParamsScalePopoverProps,
   IParamsScaleStates,
-  IParamsScaleState
 } from 'types/components/ParamsScalePopover/ParamsScalePopover';
+import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 
 import { ScaleEnum } from 'utils/d3';
 
-import './MetricsScalePopover.scss';
+import './ParamsScalePopover.scss';
 
 function ParamsScalePopover(
   props: IParamsScalePopoverProps,
 ): React.FunctionComponentElement<React.ReactNode> {
   function handleScaleChange(val: string | number, id: any) {
-    const scaleParams: IParamsScaleStates = {
-      ...props.paramsScaleType,
-      [id]: val,
-    };
-    props.onParamsScaleTypeChange(scaleParams);
+    const newParams = props.params.map((param) => {
+      if (param.key === id) {
+        param.scale = val as ScaleEnum;
+      }
+      return param;
+    });
+
+    props.onParamsScaleTypeChange(newParams);
   }
 
   return (
@@ -35,12 +38,12 @@ function ParamsScalePopover(
         >
           Select Params Scale:
         </Text>
-        {props.paramsScaleType.params.map((param: IParamsScaleState) => (
-          <div className='ParamsScalePopover__select'>
+        {props.params.map((param: ISelectOption) => (
+          <div className='ParamsScalePopover__select' key={param.key}>
             <ToggleButton
-              title={param.name + ' scale:'}
-              id={param.name}
-              value={param.scale}
+              title={param.label + ' scale:'}
+              id={param.key}
+              value={param.scale ? param.scale : ScaleEnum.Linear}
               leftValue={ScaleEnum.Linear}
               rightValue={ScaleEnum.Log}
               leftLabel='Linear'
@@ -48,8 +51,7 @@ function ParamsScalePopover(
               onChange={handleScaleChange}
             />
           </div>
-        )) 
-        }
+        ))}
       </div>
     </ErrorBoundary>
   );

--- a/src/src/components/ParamsScalePopover/ParamsScalePopover.tsx
+++ b/src/src/components/ParamsScalePopover/ParamsScalePopover.tsx
@@ -3,10 +3,7 @@ import React from 'react';
 import { Text, ToggleButton } from 'components/kit';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
-import {
-  IParamsScalePopoverProps,
-  IParamsScaleStates,
-} from 'types/components/ParamsScalePopover/ParamsScalePopover';
+import { IParamsScalePopoverProps } from 'types/components/ParamsScalePopover/ParamsScalePopover';
 import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 
 import { ScaleEnum } from 'utils/d3';
@@ -17,7 +14,7 @@ function ParamsScalePopover(
   props: IParamsScalePopoverProps,
 ): React.FunctionComponentElement<React.ReactNode> {
   function handleScaleChange(val: string | number, id: any) {
-    const newParams = props.params.map((param) => {
+    const newParams = props.selectedParams.map((param) => {
       if (param.key === id) {
         param.scale = val as ScaleEnum;
       }
@@ -38,7 +35,7 @@ function ParamsScalePopover(
         >
           Select Params Scale:
         </Text>
-        {props.params.map((param: ISelectOption) => (
+        {props.selectedParams.map((param: ISelectOption) => (
           <div className='ParamsScalePopover__select' key={param.key}>
             <ToggleButton
               title={param.label + ' scale:'}

--- a/src/src/config/analytics/analyticsKeysMap.ts
+++ b/src/src/config/analytics/analyticsKeysMap.ts
@@ -112,6 +112,8 @@ export const ANALYTICS_EVENT_KEYS = {
         },
         changeColorIndicatorMode:
           '[ParamsExplorer][Chart][Controls] Change color indicator mode', // to value
+        changeParamsScale:
+          '[ParamsExplorer][Chart][Controls] Change params scale', // to value
       },
     },
     groupings: {

--- a/src/src/config/controls/controlsDefaultConfig.ts
+++ b/src/src/config/controls/controlsDefaultConfig.ts
@@ -76,6 +76,7 @@ export const CONTROLS_DEFAULT_CONFIG = {
       selectedFields: [],
     },
     sortFields: [],
+    defaultParamsScaleType: ScaleEnum.Linear,
   },
   images: {
     alignmentType: MediaItemAlignmentEnum.Height,

--- a/src/src/pages/Params/Params.tsx
+++ b/src/src/pages/Params/Params.tsx
@@ -117,6 +117,11 @@ const Params = ({
   onParamsScaleTypeChange,
   selectedParams,
 }: IParamsProps): React.FunctionComponentElement<React.ReactNode> => {
+  let scaleStates = selectedParams.reduce((acc, param) => {
+    (acc as any)[param.key] = param.scale;
+    return acc;
+  }, {});
+
   const [isProgressBarVisible, setIsProgressBarVisible] =
     React.useState<boolean>(false);
   const chartProps: any[] = React.useMemo(() => {
@@ -126,6 +131,7 @@ const Params = ({
       onAxisBrushExtentChange,
       brushExtents,
       chartTitle: chartTitleData[chartData.data[0]?.chartIndex],
+      scaleStates,
     }));
   }, [
     highPlotData,
@@ -134,6 +140,7 @@ const Params = ({
     chartTitleData,
     onAxisBrushExtentChange,
     brushExtents,
+    scaleStates,
   ]);
 
   return (

--- a/src/src/pages/Params/Params.tsx
+++ b/src/src/pages/Params/Params.tsx
@@ -114,9 +114,8 @@ const Params = ({
   onRunsTagsChange,
   onRowsVisibilityChange,
   // todo put in appropiate place
-  paramsScaleType,
   onParamsScaleTypeChange,
-  params,
+  selectedParams,
 }: IParamsProps): React.FunctionComponentElement<React.ReactNode> => {
   const [isProgressBarVisible, setIsProgressBarVisible] =
     React.useState<boolean>(false);
@@ -229,14 +228,13 @@ const Params = ({
                           isVisibleColorIndicator={isVisibleColorIndicator}
                           selectOptions={groupingSelectOptions}
                           tooltip={tooltip}
-                          paramsScaleType={paramsScaleType}
                           onCurveInterpolationChange={
                             onCurveInterpolationChange
                           }
                           onColorIndicatorChange={onColorIndicatorChange}
                           onChangeTooltip={onChangeTooltip}
                           onParamsScaleTypeChange={onParamsScaleTypeChange}
-                          params={params}
+                          selectedParams={selectedParams}
                         />
                       }
                     />

--- a/src/src/pages/Params/Params.tsx
+++ b/src/src/pages/Params/Params.tsx
@@ -113,6 +113,10 @@ const Params = ({
   sortOptions,
   onRunsTagsChange,
   onRowsVisibilityChange,
+  // todo put in appropiate place
+  paramsScaleType,
+  onParamsScaleTypeChange,
+  params,
 }: IParamsProps): React.FunctionComponentElement<React.ReactNode> => {
   const [isProgressBarVisible, setIsProgressBarVisible] =
     React.useState<boolean>(false);
@@ -225,11 +229,14 @@ const Params = ({
                           isVisibleColorIndicator={isVisibleColorIndicator}
                           selectOptions={groupingSelectOptions}
                           tooltip={tooltip}
+                          paramsScaleType={paramsScaleType}
                           onCurveInterpolationChange={
                             onCurveInterpolationChange
                           }
                           onColorIndicatorChange={onColorIndicatorChange}
                           onChangeTooltip={onChangeTooltip}
+                          onParamsScaleTypeChange={onParamsScaleTypeChange}
+                          params={params}
                         />
                       }
                     />

--- a/src/src/pages/Params/Params.tsx
+++ b/src/src/pages/Params/Params.tsx
@@ -73,6 +73,7 @@ const Params = ({
   hiddenColumns,
   liveUpdateConfig,
   selectFormData,
+  selectedParams,
   onTableRowHover,
   onTableRowClick,
   hideSystemMetrics,
@@ -113,9 +114,7 @@ const Params = ({
   sortOptions,
   onRunsTagsChange,
   onRowsVisibilityChange,
-  // todo put in appropiate place
   onParamsScaleTypeChange,
-  selectedParams,
 }: IParamsProps): React.FunctionComponentElement<React.ReactNode> => {
   let scaleStates = selectedParams.reduce((acc, param) => {
     (acc as any)[param.key] = param.scale;

--- a/src/src/pages/Params/ParamsContainer.tsx
+++ b/src/src/pages/Params/ParamsContainer.tsx
@@ -193,9 +193,8 @@ function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
       deleteRuns={paramsAppModel.deleteRuns}
       onRowsVisibilityChange={paramsAppModel.onRowsVisibilityChange}
       // todo: Set to appropriate line
-      paramsScaleType={paramsData?.config?.chart?.paramsScaleType!}
       onParamsScaleTypeChange={paramsAppModel.onParamsScaleTypeChange}
-      params={paramsData?.config?.select?.options!}
+      selectedParams={paramsData?.config?.select?.options!}
     />
   );
 }

--- a/src/src/pages/Params/ParamsContainer.tsx
+++ b/src/src/pages/Params/ParamsContainer.tsx
@@ -192,6 +192,10 @@ function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
       archiveRuns={paramsAppModel.archiveRuns}
       deleteRuns={paramsAppModel.deleteRuns}
       onRowsVisibilityChange={paramsAppModel.onRowsVisibilityChange}
+      // todo: Set to appropriate line
+      paramsScaleType={paramsData?.config?.chart?.paramsScaleType!}
+      onParamsScaleTypeChange={paramsAppModel.onParamsScaleTypeChange}
+      params={paramsData?.config?.select?.options!}
     />
   );
 }

--- a/src/src/pages/Params/ParamsContainer.tsx
+++ b/src/src/pages/Params/ParamsContainer.tsx
@@ -154,6 +154,7 @@ function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
       tableRowHeight={paramsData?.config?.table?.rowHeight!}
       columnsWidths={paramsData?.config?.table?.columnsWidths!}
       selectFormData={paramsData?.selectFormData!}
+      selectedParams={paramsData?.config?.select?.options!}
       onColorIndicatorChange={paramsAppModel.onColorIndicatorChange}
       onCurveInterpolationChange={paramsAppModel.onCurveInterpolationChange}
       onParamsSelectChange={paramsAppModel.onParamsSelectChange}
@@ -192,9 +193,7 @@ function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
       archiveRuns={paramsAppModel.archiveRuns}
       deleteRuns={paramsAppModel.deleteRuns}
       onRowsVisibilityChange={paramsAppModel.onRowsVisibilityChange}
-      // todo: Set to appropriate line
       onParamsScaleTypeChange={paramsAppModel.onParamsScaleTypeChange}
-      selectedParams={paramsData?.config?.select?.options!}
     />
   );
 }

--- a/src/src/pages/Params/components/Controls/Controls.tsx
+++ b/src/src/pages/Params/components/Controls/Controls.tsx
@@ -30,14 +30,13 @@ function Controls(
   }, [props.tooltip]);
 
   const paramsScaleChanged: boolean = React.useMemo(() => {
-    return (
-      // returns true if any of the params scale types are different from the default
-      props.paramsScaleType.params.some(
-        (param) =>
-          param.scale !== CONTROLS_DEFAULT_CONFIG.params.defaultParamsScaleType,
-      )
+    const changed = props.params.some(
+      (param) =>
+        param.scale !== CONTROLS_DEFAULT_CONFIG.params.defaultParamsScaleType,
     );
-  }, [props.paramsScaleType]);
+    return changed;
+  }, [props.params]);
+  // todo double check if it should be props.params or props.paramsScaleType
 
   return (
     <ErrorBoundary>
@@ -100,6 +99,7 @@ function Controls(
                 <ParamsScalePopover
                   paramsScaleType={props.paramsScaleType}
                   onParamsScaleTypeChange={props.onParamsScaleTypeChange}
+                  params={props.params}
                 />
               }
             />

--- a/src/src/pages/Params/components/Controls/Controls.tsx
+++ b/src/src/pages/Params/components/Controls/Controls.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { Tooltip } from '@material-ui/core';
 
 import ControlPopover from 'components/ControlPopover/ControlPopover';
 import TooltipContentPopover from 'components/TooltipContentPopover/TooltipContentPopover';
+import ParamsScalePopover from 'components/ParamsScalePopover/ParamsScalePopover';
 import { Icon } from 'components/kit';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
@@ -26,6 +28,17 @@ function Controls(
         CONTROLS_DEFAULT_CONFIG.params.tooltip.selectedFields.length
     );
   }, [props.tooltip]);
+
+  const paramsScaleChanged: boolean = React.useMemo(() => {
+    return (
+      // returns true if any of the params scale types are different from the default
+      props.paramsScaleType.params.some(
+        (param) =>
+          param.scale !== CONTROLS_DEFAULT_CONFIG.params.defaultParamsScaleType,
+      )
+    );
+  }, [props.paramsScaleType]);
+
   return (
     <ErrorBoundary>
       <div className='Params__Controls__container'>
@@ -61,6 +74,37 @@ function Controls(
             />
           </div>
         </Tooltip>
+        <div>
+          <ErrorBoundary>
+            <ControlPopover
+              title='Params scale'
+              anchor={({ onAnchorClick, opened }) => (
+                <Tooltip title='Params scale'>
+                  <div
+                    onClick={onAnchorClick}
+                    className={classNames('Controls__anchor', {
+                      active: opened || paramsScaleChanged,
+                      outlined: !opened && paramsScaleChanged,
+                    })}
+                  >
+                    <Icon
+                      className={classNames('Controls__icon', {
+                        active: opened || paramsScaleChanged,
+                      })}
+                      name='axes-scale'
+                    />
+                  </div>
+                </Tooltip>
+              )}
+              component={
+                <ParamsScalePopover
+                  paramsScaleType={props.paramsScaleType}
+                  onParamsScaleTypeChange={props.onParamsScaleTypeChange}
+                />
+              }
+            />
+          </ErrorBoundary>
+        </div>
         <div>
           <ErrorBoundary>
             <ControlPopover

--- a/src/src/pages/Params/components/Controls/Controls.tsx
+++ b/src/src/pages/Params/components/Controls/Controls.tsx
@@ -80,13 +80,13 @@ function Controls(
                 <Tooltip title='Params scale'>
                   <div
                     onClick={onAnchorClick}
-                    className={classNames('Controls__anchor', {
+                    className={classNames('Params__Controls__anchor', {
                       active: opened || paramsScaleChanged,
                       outlined: !opened && paramsScaleChanged,
                     })}
                   >
                     <Icon
-                      className={classNames('Controls__icon', {
+                      className={classNames('Params__Controls__icon', {
                         active: opened || paramsScaleChanged,
                       })}
                       name='axes-scale'

--- a/src/src/pages/Params/components/Controls/Controls.tsx
+++ b/src/src/pages/Params/components/Controls/Controls.tsx
@@ -30,12 +30,12 @@ function Controls(
   }, [props.tooltip]);
 
   const paramsScaleChanged: boolean = React.useMemo(() => {
-    const changed = props.params.some(
+    const changed = props.selectedParams.some(
       (param) =>
         param.scale !== CONTROLS_DEFAULT_CONFIG.params.defaultParamsScaleType,
     );
     return changed;
-  }, [props.params]);
+  }, [props.selectedParams]);
   // todo double check if it should be props.params or props.paramsScaleType
 
   return (
@@ -97,9 +97,8 @@ function Controls(
               )}
               component={
                 <ParamsScalePopover
-                  paramsScaleType={props.paramsScaleType}
                   onParamsScaleTypeChange={props.onParamsScaleTypeChange}
-                  params={props.params}
+                  selectedParams={props.selectedParams}
                 />
               }
             />

--- a/src/src/pages/Params/components/Controls/Controls.tsx
+++ b/src/src/pages/Params/components/Controls/Controls.tsx
@@ -36,7 +36,6 @@ function Controls(
     );
     return changed;
   }, [props.selectedParams]);
-  // todo double check if it should be props.params or props.paramsScaleType
 
   return (
     <ErrorBoundary>

--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -121,6 +121,7 @@ import onHighlightModeChange from 'utils/app/onHighlightModeChange';
 import onIgnoreOutliersChange from 'utils/app/onIgnoreOutliersChange';
 import onSelectOptionsChange from 'utils/app/onSelectOptionsChange';
 import onMetricVisibilityChange from 'utils/app/onMetricsVisibilityChange';
+import onParamsScaleTypeChange from 'utils/app/onParamsScaleTypeChange';
 import onParamVisibilityChange from 'utils/app/onParamsVisibilityChange';
 import onRowHeightChange from 'utils/app/onRowHeightChange';
 import onRowVisibilityChange from 'utils/app/onRowVisibilityChange';
@@ -4773,6 +4774,9 @@ function createAppModel(appConfig: IAppInitialConfig) {
               model,
               updateModelData,
             });
+          },
+          onParamsScaleTypeChange(args: any): void {
+            onParamsScaleTypeChange({ args, model, appName, updateModelData });
           },
         });
       }

--- a/src/src/types/components/HighPlot/HighPlot.d.ts
+++ b/src/src/types/components/HighPlot/HighPlot.d.ts
@@ -3,7 +3,7 @@ import { ResizeModeEnum } from 'config/enums/tableEnums';
 import { ISyncHoverStateArgs } from 'types/utils/d3/drawHoverAttributes';
 import { IChartTitle } from 'types/services/models/metrics/metricsAppModel';
 
-import { CurveEnum } from 'utils/d3';
+import { CurveEnum, ScaleEnum } from 'utils/d3';
 
 export interface IHighPlotProps {
   index: number;
@@ -28,4 +28,7 @@ export interface IHighPlotProps {
   onMount?: () => void;
   readOnly?: boolean;
   margin?: { top: number; right: number; bottom: number; left: number };
+  scaleStates?: {
+    [key: string]: ScaleEnum;
+  };
 }

--- a/src/src/types/components/ParamsScalePopover/ParamsScalePopover.d.ts
+++ b/src/src/types/components/ParamsScalePopover/ParamsScalePopover.d.ts
@@ -1,0 +1,15 @@
+import { ScaleEnum } from 'utils/d3';
+
+export interface IParamsScaleState {
+  name: string;
+  scale: ScaleEnum;
+}
+
+export interface IParamsScaleStates {
+  params: IParamsScaleState[];
+}
+
+export interface IParamsScalePopoverProps {
+  onParamsScaleTypeChange: (params: IParamsScaleStates) => void;
+  paramsScaleType: IParamsScaleStates;
+}

--- a/src/src/types/components/ParamsScalePopover/ParamsScalePopover.d.ts
+++ b/src/src/types/components/ParamsScalePopover/ParamsScalePopover.d.ts
@@ -1,3 +1,4 @@
+import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 import { ScaleEnum } from 'utils/d3';
 
 export interface IParamsScaleState {
@@ -10,6 +11,7 @@ export interface IParamsScaleStates {
 }
 
 export interface IParamsScalePopoverProps {
-  onParamsScaleTypeChange: (params: IParamsScaleStates) => void;
+  onParamsScaleTypeChange: (params: ISelectOption[]) => void;
   paramsScaleType: IParamsScaleStates;
+  params: ISelectOption[];
 }

--- a/src/src/types/components/ParamsScalePopover/ParamsScalePopover.d.ts
+++ b/src/src/types/components/ParamsScalePopover/ParamsScalePopover.d.ts
@@ -1,17 +1,7 @@
 import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 import { ScaleEnum } from 'utils/d3';
 
-export interface IParamsScaleState {
-  name: string;
-  scale: ScaleEnum;
-}
-
-export interface IParamsScaleStates {
-  params: IParamsScaleState[];
-}
-
 export interface IParamsScalePopoverProps {
   onParamsScaleTypeChange: (params: ISelectOption[]) => void;
-  paramsScaleType: IParamsScaleStates;
-  params: ISelectOption[];
+  selectedParams: ISelectOption[];
 }

--- a/src/src/types/pages/params/Params.d.ts
+++ b/src/src/types/pages/params/Params.d.ts
@@ -81,6 +81,7 @@ export interface IParamsProps extends Partial<RouteChildrenProps> {
   };
   columnsOrder: IColumnsOrder;
   sameValueColumns: string[] | [];
+  selectedParams: ISelectOption[];
   onNotificationDelete: (id: number) => void;
   onCurveInterpolationChange: () => void;
   onActivePointChange: (
@@ -124,7 +125,5 @@ export interface IParamsProps extends Partial<RouteChildrenProps> {
   archiveRuns: (ids: string[], archived: boolean) => void;
   deleteRuns: (ids: string[]) => void;
   onRowsVisibilityChange: (metricKeys: string[]) => void;
-  // todo move to appropiate place
   onParamsScaleTypeChange: (params: ISelectOption[]) => void;
-  selectedParams: ISelectOption[];
 }

--- a/src/src/types/pages/params/Params.d.ts
+++ b/src/src/types/pages/params/Params.d.ts
@@ -124,4 +124,8 @@ export interface IParamsProps extends Partial<RouteChildrenProps> {
   archiveRuns: (ids: string[], archived: boolean) => void;
   deleteRuns: (ids: string[]) => void;
   onRowsVisibilityChange: (metricKeys: string[]) => void;
+  // todo move to appropiate place
+  paramsScaleType: IParamsScaleStates;
+  onParamsScaleTypeChange: (params: IParamsScaleStates) => void;
+  params: ISelectOption[];
 }

--- a/src/src/types/pages/params/Params.d.ts
+++ b/src/src/types/pages/params/Params.d.ts
@@ -125,7 +125,6 @@ export interface IParamsProps extends Partial<RouteChildrenProps> {
   deleteRuns: (ids: string[]) => void;
   onRowsVisibilityChange: (metricKeys: string[]) => void;
   // todo move to appropiate place
-  paramsScaleType: IParamsScaleStates;
-  onParamsScaleTypeChange: (params: IParamsScaleStates) => void;
-  params: ISelectOption[];
+  onParamsScaleTypeChange: (params: ISelectOption[]) => void;
+  selectedParams: ISelectOption[];
 }

--- a/src/src/types/pages/params/components/Controls/Controls.d.ts
+++ b/src/src/types/pages/params/components/Controls/Controls.d.ts
@@ -3,8 +3,6 @@ import {
   ITooltip,
 } from 'types/services/models/metrics/metricsAppModel';
 
-import { IParamsScaleStates } from 'types/components/ParamsScalePopover/ParamsScalePopover';
-
 import { CurveEnum } from 'utils/d3';
 import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 
@@ -13,10 +11,9 @@ export interface IControlProps {
   isVisibleColorIndicator: boolean;
   selectOptions: IGroupingSelectOption[];
   tooltip?: ITooltip;
-  paramsScaleType: IParamsScaleStates;
   onColorIndicatorChange: () => void;
   onCurveInterpolationChange: () => void;
   onChangeTooltip: (tooltip: Partial<ITooltip>) => void;
   onParamsScaleTypeChange: (args: ISelectOption[]) => void;
-  params: ISelectOption[];
+  selectedParams: ISelectOption[];
 }

--- a/src/src/types/pages/params/components/Controls/Controls.d.ts
+++ b/src/src/types/pages/params/components/Controls/Controls.d.ts
@@ -3,14 +3,20 @@ import {
   ITooltip,
 } from 'types/services/models/metrics/metricsAppModel';
 
+import { IParamsScaleStates } from 'types/components/ParamsScalePopover/ParamsScalePopover';
+
 import { CurveEnum } from 'utils/d3';
+import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 
 export interface IControlProps {
   curveInterpolation: CurveEnum;
   isVisibleColorIndicator: boolean;
   selectOptions: IGroupingSelectOption[];
   tooltip?: ITooltip;
+  paramsScaleType: IParamsScaleStates;
   onColorIndicatorChange: () => void;
   onCurveInterpolationChange: () => void;
   onChangeTooltip: (tooltip: Partial<ITooltip>) => void;
+  onParamsScaleTypeChange: (args: ISelectOption[]) => void;
+  params: ISelectOption[];
 }

--- a/src/src/types/services/models/explorer/createAppModel.d.ts
+++ b/src/src/types/services/models/explorer/createAppModel.d.ts
@@ -26,7 +26,7 @@ import {
   ITrendlineOptions,
 } from 'types/services/models/scatter/scatterAppModel';
 
-import { ChartTypeEnum, CurveEnum, HighlightEnum } from 'utils/d3';
+import { ChartTypeEnum, CurveEnum, HighlightEnum, ScaleEnum } from 'utils/d3';
 
 import { IImagesExploreAppModelState } from '../imagesExplore/imagesExploreAppModel';
 
@@ -102,6 +102,7 @@ export interface ISelectOption {
     option_name: string;
     context: { [key: string]: unknown } | null | any;
   };
+  scale?: ScaleEnum;
 }
 
 export interface ISelectConfig {
@@ -151,6 +152,7 @@ export interface IHighPlotConfig {
       [key: string]: [number, number] | [string, string];
     };
   };
+  // paramsScaleType: IParamsScaleStates;
 }
 
 export interface ILineChartConfig {

--- a/src/src/types/utils/d3/drawParallelAxes.d.ts
+++ b/src/src/types/utils/d3/drawParallelAxes.d.ts
@@ -26,4 +26,5 @@ export interface IDrawParallelAxesProps {
   axesRef: React.MutableRefObject<>;
   dimensions: IDimensionsType;
   plotBoxRef: React.MutableRefObject<>;
+  scaleStates: React.MutableRefObject<>;
 }

--- a/src/src/utils/app/onParamsScaleTypeChange.ts
+++ b/src/src/utils/app/onParamsScaleTypeChange.ts
@@ -37,6 +37,6 @@ export default function onParamsScaleTypeChange<M extends State>({
   // todo create analytics keys and change this
   analytics.trackEvent(
     // @ts-ignore
-    `${ANALYTICS_EVENT_KEYS[appName].chart.controls.changeParamsScale} to "${args.xAxis}"`,
+    `${ANALYTICS_EVENT_KEYS[appName].chart.controls.changeParamsScale} to "${args}"`,
   );
 }

--- a/src/src/utils/app/onParamsScaleTypeChange.ts
+++ b/src/src/utils/app/onParamsScaleTypeChange.ts
@@ -1,0 +1,43 @@
+import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
+
+import * as analytics from 'services/analytics';
+
+import { IParamsScaleStates } from 'types/components/ParamsScalePopover/ParamsScalePopover';
+import { IModel, State } from 'types/services/models/model';
+import { IAppModelConfig } from 'types/services/models/explorer/createAppModel';
+
+export default function onParamsScaleTypeChange<M extends State>({
+  args,
+  model,
+  appName,
+  updateModelData,
+}: {
+  args: IParamsScaleStates;
+  model: IModel<M>;
+  appName: string;
+  updateModelData: (
+    configData: IAppModelConfig | any,
+    shouldURLUpdate?: boolean,
+  ) => void;
+}): void {
+  let configData = model?.getState()?.config;
+  if (configData?.chart) {
+    configData = {
+      ...configData,
+      chart: {
+        ...configData.chart,
+        paramsScaleType: args,
+      },
+    };
+    model.setState({ config: configData });
+    updateModelData(configData, true);
+  }
+  analytics.trackEvent(
+    // @ts-ignore
+    `${ANALYTICS_EVENT_KEYS[appName].chart.controls.changeParamsScale} to "${args.xAxis}"`,
+  );
+  analytics.trackEvent(
+    // @ts-ignore
+    `${ANALYTICS_EVENT_KEYS[appName].chart.controls.changeParamsScale} to "${args.yAxis}"`,
+  );
+}

--- a/src/src/utils/app/onParamsScaleTypeChange.ts
+++ b/src/src/utils/app/onParamsScaleTypeChange.ts
@@ -2,9 +2,11 @@ import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 
 import * as analytics from 'services/analytics';
 
-import { IParamsScaleStates } from 'types/components/ParamsScalePopover/ParamsScalePopover';
 import { IModel, State } from 'types/services/models/model';
-import { IAppModelConfig } from 'types/services/models/explorer/createAppModel';
+import {
+  IAppModelConfig,
+  ISelectOption,
+} from 'types/services/models/explorer/createAppModel';
 
 export default function onParamsScaleTypeChange<M extends State>({
   args,
@@ -12,7 +14,7 @@ export default function onParamsScaleTypeChange<M extends State>({
   appName,
   updateModelData,
 }: {
-  args: IParamsScaleStates;
+  args: ISelectOption[];
   model: IModel<M>;
   appName: string;
   updateModelData: (
@@ -24,20 +26,17 @@ export default function onParamsScaleTypeChange<M extends State>({
   if (configData?.chart) {
     configData = {
       ...configData,
-      chart: {
-        ...configData.chart,
-        paramsScaleType: args,
+      select: {
+        ...configData.select,
+        options: args,
       },
     };
     model.setState({ config: configData });
     updateModelData(configData, true);
   }
+  // todo create analytics keys and change this
   analytics.trackEvent(
     // @ts-ignore
     `${ANALYTICS_EVENT_KEYS[appName].chart.controls.changeParamsScale} to "${args.xAxis}"`,
-  );
-  analytics.trackEvent(
-    // @ts-ignore
-    `${ANALYTICS_EVENT_KEYS[appName].chart.controls.changeParamsScale} to "${args.yAxis}"`,
   );
 }

--- a/src/src/utils/d3/drawParallelAxes.ts
+++ b/src/src/utils/d3/drawParallelAxes.ts
@@ -20,6 +20,7 @@ function drawParallelAxes({
   axesRef,
   dimensions,
   plotBoxRef,
+  scaleStates,
 }: IDrawParallelAxesProps): void {
   if (!axesNodeRef?.current && !dimensions && _.isEmpty(dimensions)) {
     return;
@@ -55,10 +56,10 @@ function drawParallelAxes({
       dimensions[keyOfDimension];
     const first = 0;
     const last = keysOfDimensions.length - 1;
-
     const tmpYScale = getAxisScale({
       domainData,
-      scaleType,
+      scaleType:
+        scaleType == ScaleEnum.Point ? scaleType : scaleStates[keyOfDimension],
       rangeData: [height - margin.top - margin.bottom, 0],
     });
     yScale[keyOfDimension] = tmpYScale;


### PR DESCRIPTION
Hi, this is a preliminary PR for https://github.com/G-Research/fasttrackml/issues/67. I have added a new `ParamsScalePopover` component, which is similar to the `AxesScalePopover`, but should display a list of all the tracked params.

Please let me know if there's anything that doesn't make sense or needs to be changed!

**To do:**
- Figure out how to handle Point params such as strings
- ~~Fix styling issues with the popup trigger button not showing the appropriate active/hover state~~

## Changelog:
- Added `ParamsScalePopover` component to the Params Controls
- Added support for scale changes on `HighPlot` chart
  - Implemented onParamsScaleTypeChange() to update params state
  - Added `onParamsScaleTypeChange()` and `selectedParams` to relevant classes