### PR TITLE
Fix Metric/Params selection dropdown search text disappears with left key

### DIFF
--- a/src/src/components/SelectFormPopper/SelectFormPopper.tsx
+++ b/src/src/components/SelectFormPopper/SelectFormPopper.tsx
@@ -37,7 +37,7 @@ const SelectFormPopper: React.FC<ISelectFormPopperProps> = ({
   classes,
 }) => {
   const handleKeyDown = (event) => {
-    if (event.keyCode === 37) {
+    if (event.key === 'ArrowLeft') {
       event.stopPropagation();
     }
   };

--- a/src/src/components/SelectFormPopper/SelectFormPopper.tsx
+++ b/src/src/components/SelectFormPopper/SelectFormPopper.tsx
@@ -36,6 +36,11 @@ const SelectFormPopper: React.FC<ISelectFormPopperProps> = ({
   className,
   classes,
 }) => {
+  const handleKeyDown = (event) => {
+    if (event.keyCode === 37) {
+      event.stopPropagation();
+    }
+  };
   return (
     <Popper
       id={id}
@@ -90,6 +95,7 @@ const SelectFormPopper: React.FC<ISelectFormPopperProps> = ({
                 ...params.inputProps,
                 value: searchValue,
                 onChange: handleSearchInputChange,
+                onKeyDown: handleKeyDown,
               }}
               spellCheck={false}
               placeholder='Search'


### PR DESCRIPTION
Fixes: https://github.com/G-Research/fasttrackml/issues/953.
Stop propagating the left arrow key event thrown by the InputBase which had a conflict with the Autocomplete component. 