### PR TITLE
Experiment Regex Fixes

### DIFF
--- a/src/src/pages/Experiment/components/ExperimentSelectionPopover/ExperimentSelectionPopover.tsx
+++ b/src/src/pages/Experiment/components/ExperimentSelectionPopover/ExperimentSelectionPopover.tsx
@@ -182,6 +182,12 @@ function ExperimentSelectionPopover({
                     selected={isRegexSearch}
                     onChange={() => {
                       setIsRegexSearch(!isRegexSearch);
+
+                      if (!isRegexSearch) {
+                        handleRegexSearch(searchValue);
+                      } else {
+                        handleSimpleSearch(searchValue);
+                      }
                     }}
                     className='RegexToggle'
                   >

--- a/src/src/pages/Experiment/components/ExperimentSelectionPopover/ExperimentSelectionPopover.tsx
+++ b/src/src/pages/Experiment/components/ExperimentSelectionPopover/ExperimentSelectionPopover.tsx
@@ -77,22 +77,31 @@ function ExperimentSelectionPopover({
     setSearchValue(e.target.value);
 
     if (isRegexSearch) {
-      try {
-        const regex = new RegExp(e.target.value, 'i');
-        setInvalidRegex(false);
-        const options = experimentsData?.filter((experiment) =>
-          regex.test(experiment.name),
-        );
-        setVisibleExperiments(options || []);
-      } catch (error) {
-        setInvalidRegex(true);
-      }
+      handleRegexSearch(e.target.value);
     } else {
+      handleSimpleSearch(e.target.value);
+    }
+  }
+
+  function handleRegexSearch(search: string): void {
+    try {
+      const regex = new RegExp(search, 'i');
+      setInvalidRegex(false);
       const options = experimentsData?.filter((experiment) =>
-        experiment.name.toLowerCase().includes(e.target.value.toLowerCase()),
+        regex.test(experiment.name),
       );
       setVisibleExperiments(options || []);
+    } catch (error) {
+      setInvalidRegex(true);
     }
+  }
+
+  function handleSimpleSearch(search: string): void {
+    setInvalidRegex(false);
+    const options = experimentsData?.filter((experiment) =>
+      experiment.name.toLowerCase().includes(search.toLowerCase()),
+    );
+    setVisibleExperiments(options || []);
   }
 
   function toggleAllExperiments(checked: boolean): void {


### PR DESCRIPTION
These are fixes for issues https://github.com/G-Research/fasttrackml/issues/1023 and https://github.com/G-Research/fasttrackml/issues/1024.

## Changelog
- Toggling regex mode updates the validity status based on current values
- Toggling regex mode updates the selected experiments appropriately