### PR TITLE
Fix various experiment header issues

### DIFF
--- a/src/src/pages/Metrics/components/MetricsBar/MetricsBar.tsx
+++ b/src/src/pages/Metrics/components/MetricsBar/MetricsBar.tsx
@@ -35,6 +35,9 @@ function MetricsBar({
   onToggleAllExperiments,
 }: IMetricsBarProps): React.FunctionComponentElement<React.ReactNode> {
   const [popover, setPopover] = React.useState<string>('');
+  const [selectedExperimentNames, setSelectedExperimentNames] = React.useState<
+    string[]
+  >(getSelectedExperimentNames());
 
   const route = useRouteMatch<any>();
 
@@ -47,8 +50,6 @@ function MetricsBar({
 
   const { data: experimentsData, loading: isExperimentsLoading } =
     experimentsState;
-
-  const selectedExperimentNames = getSelectedExperimentNames();
 
   function handleBookmarkClick(value: string): void {
     setPopover(value);
@@ -65,6 +66,7 @@ function MetricsBar({
 
   function handleExperimentNamesChange(experimentName: string): void {
     onSelectExperimentNamesChange(experimentName);
+    setSelectedExperimentNames(getSelectedExperimentNames());
   }
 
   return (

--- a/src/src/pages/Metrics/components/SelectForm/SelectForm.scss
+++ b/src/src/pages/Metrics/components/SelectForm/SelectForm.scss
@@ -131,14 +131,15 @@
   margin: 10px;
 }
 
-.Popper__SelectForm__select{
+.Popper__SelectForm__select {
   @extend .Metrics__SelectForm__metric__select;
 }
 
-.Popper__SelectForm__option{
+.Popper__SelectForm__option {
   @extend .Metrics__SelectForm__option !optional;
 }
 
-.Popper__SelectForm__option__label{
+.Popper__SelectForm__option__label {
   @extend .Metrics__SelectForm__option__label !optional;
+  margin-left: $space-xs;
 }

--- a/src/src/pages/Params/components/SelectForm/SelectForm.scss
+++ b/src/src/pages/Params/components/SelectForm/SelectForm.scss
@@ -117,14 +117,15 @@
   margin: 10px;
 }
 
-.Popper__SelectForm__select{
+.Popper__SelectForm__select {
   @extend .SelectForm__param__select;
 }
 
-.Popper__SelectForm__option{
+.Popper__SelectForm__option {
   @extend .SelectForm__option !optional;
 }
 
-.Popper__SelectForm__option__label{
+.Popper__SelectForm__option__label {
   @extend .SelectForm__option__label !optional;
+  margin-left: $space-xs;
 }

--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -128,7 +128,6 @@ import onRowHeightChange from 'utils/app/onRowHeightChange';
 import onRowVisibilityChange from 'utils/app/onRowVisibilityChange';
 import onSelectExperimentNamesChange from 'utils/app/onSelectExperimentNamesChange';
 import onToggleAllExperiments from 'utils/app/onToggleAllExperiments';
-import onSelectAdvancedQueryChange from 'utils/app/onSelectAdvancedQueryChange';
 import onSelectRunQueryChange from 'utils/app/onSelectRunQueryChange';
 import onSmoothingChange from 'utils/app/onSmoothingChange';
 import onSortFieldsChange from 'utils/app/onSortFieldsChange';
@@ -647,35 +646,36 @@ function createAppModel(appConfig: IAppInitialConfig) {
               selectedRows: shouldResetSelectedRows
                 ? {}
                 : model.getState()?.selectedRows,
-          });
-          liveUpdateInstance?.stop().then();
-          try {
-            const stream = await metricsRequestRef.call((detail) => {
-              exceptionHandler({ detail, model });
-              resetModelState(configData, shouldResetSelectedRows!);
             });
-            const runData = await getRunData(stream, (progress) =>
-              setRequestProgress(model, progress),
-            );
-            if (shouldUrlUpdate) {
-              updateURL({ configData, appName });
+            liveUpdateInstance?.stop().then();
+            try {
+              const stream = await metricsRequestRef.call((detail) => {
+                exceptionHandler({ detail, model });
+                resetModelState(configData, shouldResetSelectedRows!);
+              });
+              const runData = await getRunData(stream, (progress) =>
+                setRequestProgress(model, progress),
+              );
+              if (shouldUrlUpdate) {
+                updateURL({ configData, appName });
+              }
+              saveRecentSearches(appName, query);
+              updateData(runData);
+            } catch (ex: Error | any) {
+              if (ex.name === 'AbortError') {
+                // Abort Error
+              } else {
+                // eslint-disable-next-line no-console
+                console.log('Unhandled error: ', ex);
+              }
             }
-            saveRecentSearches(appName, query);
-            updateData(runData);
-          } catch (ex: Error | any) {
-            if (ex.name === 'AbortError') {
-              // Abort Error
-            } else {
-              // eslint-disable-next-line no-console
-              console.log('Unhandled error: ', ex);
-            }
-          }
 
-          liveUpdateInstance?.start({
-            q: query,
-            p: configData?.chart?.densityType,
-            ...(metric && { x_axis: metric }),
-          });
+            liveUpdateInstance?.start({
+              q: query,
+              p: configData?.chart?.densityType,
+              ...(metric && { x_axis: metric }),
+            });
+          }
         },
         abort: metricsRequestRef.abort,
       };

--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -628,7 +628,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
       setRequestProgress(model);
       return {
         call: async () => {
-          if (query === '()') {
+          if (_.isEmpty(configData?.select?.options)) {
             resetModelState(configData, shouldResetSelectedRows!);
           } else {
             model.setState({

--- a/src/src/utils/app/onSelectExperimentNamesChange.ts
+++ b/src/src/utils/app/onSelectExperimentNamesChange.ts
@@ -33,7 +33,10 @@ export default function onSelectExperimentNamesChange<M extends State>({
   if (configData?.select) {
     const newConfig = {
       ...configData,
-      select: { ...configData.select, selectedExperimentNames },
+      select: {
+        ...configData.select,
+        selectedExperimentNames,
+      },
     };
     model.setState({ config: newConfig });
   }


### PR DESCRIPTION
Fixes for https://github.com/G-Research/fasttrackml/issues/1021 and https://github.com/G-Research/fasttrackml/issues/1022.

### #1021
This fixed an issue with the console erroring out on empty metrics query:
![image](https://github.com/G-Research/fasttrackml-ui-aim/assets/97265671/5dc7449c-7b54-4701-aada-a88df39840e3)

Now we get the desired "No Results" page, and no query is done on backend.

### #1022
The issue was that when I wrote the `ExperimentSelectionHeader`, I did not add the `selectedExperimentNames` as a state within the `MetricsBar`. The state was working correctly under normal circumstances because the view was getting refreshed anyways when querying. Empty queries are not sent to the server to begin with, therefore no refresh was happening.

Explanation: Added extra state to `MetricsBar` and set it on the handler function:
- `onSelectExperimentNamesChange()` changes the model and toggles the experiment internally
- `setSelectedExperiments()` updates the view to reflect the recent changes

Note: #1021 was also affected by these changes and has been tested as well.

### Extra
I fixed a small misalignment in the `SelectFormPopper` metrics/params.