### PR TITLE
Fix Experiment Selector Namespace Bug

### DIFF
--- a/src/src/pages/Experiment/useExperimentState.tsx
+++ b/src/src/pages/Experiment/useExperimentState.tsx
@@ -5,7 +5,7 @@ import { IExperimentData } from 'modules/core/api/experimentsApi';
 
 import experimentEngine from './ExperimentStore';
 
-function useExperimentState(experimentId: string) {
+function useExperimentState(experimentId?: string) {
   const { current: engine } = React.useRef(experimentEngine);
   const experimentState: IResourceState<IExperimentData> =
     engine.experimentState((state) => state);
@@ -21,7 +21,12 @@ function useExperimentState(experimentId: string) {
   }, []);
 
   React.useEffect(() => {
-    engine.fetchExperimentData(experimentId as any);
+    if (experimentId) {
+      engine.fetchExperimentData(experimentId as any);
+    } else {
+      // Fetch the default experiment in the namespace
+      engine.fetchExperimentsData();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [experimentId]);
 

--- a/src/src/pages/Metrics/components/MetricsBar/MetricsBar.tsx
+++ b/src/src/pages/Metrics/components/MetricsBar/MetricsBar.tsx
@@ -13,6 +13,10 @@ import ConfirmModal from 'components/ConfirmModal/ConfirmModal';
 
 import { DOCUMENTATIONS } from 'config/references';
 
+import { IResourceState } from 'modules/core/utils/createResource';
+import { IExperimentData } from 'modules/core/api/experimentsApi';
+
+import createExperimentEngine from 'pages/Dashboard/components/ExploreSection/ExperimentsCard/ExperimentsStore';
 import ExperimentBar from 'pages/Experiment/components/ExperimentBar';
 import useExperimentState from 'pages/Experiment/useExperimentState';
 
@@ -41,9 +45,22 @@ function MetricsBar({
 
   const route = useRouteMatch<any>();
 
+  const { current: experimentsEngine } = React.useRef(createExperimentEngine);
+
+  const experimentsStore: IResourceState<IExperimentData[]> =
+    experimentsEngine.experimentsState((state) => state);
+
+  React.useEffect(() => {
+    experimentsEngine.fetchExperiments();
+    return () => {
+      experimentsEngine.destroy();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Fetch all experiments along with default
   const { experimentState, experimentsState, getExperimentsData } =
-    useExperimentState('0');
+    useExperimentState(experimentsStore.data?.[0]?.id);
 
   const { data: experimentData, loading: isExperimentLoading } =
     experimentState;


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/1054.

Backend PR: https://github.com/G-Research/fasttrackml/pull/1066

### Changelog
- Change initial experiment state on `MetricsBar` to reflect the current namespace's "Default" experiment
- Update backend to force ascending order for experiments in array

If testing, keep in mind that when switching workspaces in dev, the port will change from 3000 to 5000 which may cause unintended behaviours.