### PR TITLE
Run Selector UX Improvements

### DIFF
--- a/src/src/pages/Metrics/Metrics.scss
+++ b/src/src/pages/Metrics/Metrics.scss
@@ -60,7 +60,6 @@
   display: flex;
   border-bottom: $border-main;
   min-height: 6rem;
-  max-height: 6rem;
 }
 
 .Metrics__table__aggregationColumn__cell {

--- a/src/src/pages/Metrics/components/SelectForm/SelectForm.scss
+++ b/src/src/pages/Metrics/components/SelectForm/SelectForm.scss
@@ -11,16 +11,22 @@
     flex-direction: column;
     justify-content: space-between;
     padding-right: 1rem;
-    height: 4.5rem;
+    min-height: 4.5rem;
     /* TODO [GA]: Override MUI default styles in a nice way */
     .MuiBox-root {
       justify-content: flex-start;
     }
   }
+
+  &__metricsButton {
+    margin-top: $space-xs;
+    margin-bottom: $space-xs;
+  }
+
   &__container__search {
     width: 103px;
     display: flex;
-    justify-content: space-between;
+    justify-content: baseline;
     flex-direction: column;
   }
   &__Popper {
@@ -46,6 +52,7 @@
   }
   &__TextField {
     position: relative;
+    width: 100%;
   }
   &__textarea {
     flex: 1;
@@ -56,6 +63,7 @@
   }
   &__search__button {
     width: 100%;
+    margin-top: $space-xs;
   }
   &__search__actions {
     display: flex;
@@ -82,6 +90,7 @@
     justify-content: center;
     cursor: pointer;
     position: relative;
+    display: inline-flex;
     &.disabled {
       opacity: 0.5;
     }
@@ -90,12 +99,6 @@
       position: absolute;
       width: 20px;
       height: 34px;
-      background: rgba(255, 255, 255, 0.5);
-      background: linear-gradient(
-        90deg,
-        rgba(255, 255, 255, 0) 0%,
-        rgba(255, 255, 255, 1) 92%
-      );
       left: -20px;
       top: -5px;
       border-radius: 0;
@@ -109,14 +112,18 @@
     }
   }
   &__tags {
-    display: flex;
     align-items: center;
     overflow: auto;
     max-width: calc(100vw - 40rem);
     min-width: 12rem;
+    padding-top: 1px;
 
+    // Increase height if too many tags
+    max-height: 16rem;
+    display: block;
     .Badge {
-      margin-right: 0.5rem;
+      margin-right: $space-xxxs;
+      margin-bottom: 1px;
       &:last-child {
         margin-right: 20px;
       }

--- a/src/src/pages/Metrics/components/SelectForm/SelectForm.scss
+++ b/src/src/pages/Metrics/components/SelectForm/SelectForm.scss
@@ -85,7 +85,6 @@
     width: 24px;
     background: #e8f1fc;
     border-radius: 6px;
-    display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
@@ -113,14 +112,16 @@
   }
   &__tags {
     align-items: center;
-    overflow: auto;
-    max-width: calc(100vw - 40rem);
     min-width: 12rem;
     padding-top: 1px;
 
-    // Increase height if too many tags
-    max-height: 16rem;
+    max-height: 3.2rem;
     display: block;
+  
+    overflow-y: scroll;
+    scrollbar-color: auto;
+    scrollbar-width: thin;
+    overflow-x: hidden;
     .Badge {
       margin-right: $space-xxxs;
       margin-bottom: 1px;

--- a/src/src/pages/Metrics/components/SelectForm/SelectForm.tsx
+++ b/src/src/pages/Metrics/components/SelectForm/SelectForm.tsx
@@ -152,106 +152,96 @@ function SelectForm({
             justifyContent='space-between'
             alignItems='center'
           >
-            <Box display='flex' alignItems='center'>
-              <Button
-                variant='contained'
-                color='primary'
-                onClick={handleClick}
-                aria-describedby={id}
+            <div className='Metrics__SelectForm__TextField'>
+              <AutocompleteInput
+                refObject={autocompleteRef}
+                error={selectFormData.error}
+                value={selectedMetricsData?.query}
+                context={selectFormData.suggestions}
+                onEnter={handleMetricSearch}
                 disabled={isDisabled}
-              >
-                <Icon name='plus' style={{ marginRight: '0.5rem' }} />
-                Metrics
-              </Button>
-              <SelectFormPopper
-                id={id}
-                type='metrics'
-                open={open}
-                anchorEl={anchorEl}
-                options={options}
-                selectedData={selectedMetricsData}
-                onSelect={onSelect}
-                searchValue={searchValue}
-                handleSearchInputChange={handleSearchInputChange}
-                handleClose={handleClose}
-                regexError={regexError}
-                setRegexError={setRegexError}
-                isRegexSearch={isRegexSearch}
-                setIsRegexSearch={setIsRegexSearch}
-                className='Metrics__SelectForm__Popper'
-                classes={classes}
               />
-              <Divider
-                style={{ margin: '0 1rem' }}
-                orientation='vertical'
-                flexItem
-              />
-              {selectedMetricsData?.options.length === 0 && (
-                <Text tint={50} size={14} weight={400}>
-                  No metrics are selected
-                </Text>
-              )}
-              <Box
-                className='Metrics__SelectForm__tags ScrollBar__hidden'
-                flex={1}
-              >
-                {selectedMetricsData?.options?.map((tag: ISelectOption) => {
-                  return (
-                    <Badge
-                      size='large'
-                      key={tag.label}
-                      label={tag.label}
-                      value={tag.key}
-                      onDelete={handleDelete}
-                      disabled={isDisabled}
-                    />
-                  );
-                })}
-              </Box>
-            </Box>
-            {selectedMetricsData?.options &&
-              selectedMetricsData.options.length > 1 && (
-                <Button
-                  onClick={() => onMetricsSelectChange([])}
-                  withOnlyIcon
-                  className={classNames('Metrics__SelectForm__clearAll', {
-                    disabled: isDisabled,
-                  })}
-                  size='xSmall'
-                  disabled={isDisabled}
-                >
-                  <Icon name='close' />
-                </Button>
-              )}
+            </div>
           </Box>
-          <div className='Metrics__SelectForm__TextField'>
-            <AutocompleteInput
-              refObject={autocompleteRef}
-              error={selectFormData.error}
-              value={selectedMetricsData?.query}
-              context={selectFormData.suggestions}
-              onEnter={handleMetricSearch}
+          <Box
+            display='flex'
+            alignItems='center'
+            className='Metrics__SelectForm__metricsBox'
+          >
+            <Button
+              variant='contained'
+              color='primary'
+              onClick={handleClick}
+              aria-describedby={id}
               disabled={isDisabled}
+              className='Metrics__SelectForm__metricsButton'
+            >
+              <Icon name='plus' style={{ marginRight: '0.5rem' }} />
+              Metrics
+            </Button>
+            <SelectFormPopper
+              id={id}
+              type='metrics'
+              open={open}
+              anchorEl={anchorEl}
+              options={options}
+              selectedData={selectedMetricsData}
+              onSelect={onSelect}
+              searchValue={searchValue}
+              handleSearchInputChange={handleSearchInputChange}
+              handleClose={handleClose}
+              regexError={regexError}
+              setRegexError={setRegexError}
+              isRegexSearch={isRegexSearch}
+              setIsRegexSearch={setIsRegexSearch}
+              className='Metrics__SelectForm__Popper'
+              classes={classes}
             />
-          </div>
+            <Divider
+              style={{ margin: '0 1rem' }}
+              orientation='vertical'
+              flexItem
+            />
+            {selectedMetricsData?.options.length === 0 && (
+              <Text tint={50} size={14} weight={400}>
+                No metrics are selected
+              </Text>
+            )}
+            {/* Box must expand vertically if too many metrics are selected */}
+            <Box
+              className='Metrics__SelectForm__tags ScrollBar__hidden'
+              flex={1}
+            >
+              {selectedMetricsData?.options?.map((tag: ISelectOption) => {
+                return (
+                  <Badge
+                    size='small'
+                    key={tag.label}
+                    label={tag.label}
+                    value={tag.key}
+                    onDelete={handleDelete}
+                    disabled={isDisabled}
+                  />
+                );
+              })}
+              {selectedMetricsData?.options &&
+                selectedMetricsData.options.length > 1 && (
+                  <Button
+                    onClick={() => onMetricsSelectChange([])}
+                    withOnlyIcon
+                    className={classNames('Metrics__SelectForm__clearAll', {
+                      disabled: isDisabled,
+                    })}
+                    size='xSmall'
+                    disabled={isDisabled}
+                  >
+                    <Icon name='close' />
+                  </Button>
+                )}
+            </Box>
+          </Box>
         </div>
         <div className='Metrics__SelectForm__container__search'>
-          <Button
-            fullWidth
-            key={`${requestIsPending}`}
-            color='primary'
-            variant={requestIsPending ? 'outlined' : 'contained'}
-            startIcon={
-              <Icon
-                name={requestIsPending ? 'close' : 'search'}
-                fontSize={requestIsPending ? 12 : 14}
-              />
-            }
-            className='Metrics__SelectForm__search__button'
-            onClick={requestIsPending ? handleRequestAbort : handleMetricSearch}
-          >
-            {requestIsPending ? 'Cancel' : 'Search'}
-          </Button>
           <div className='Metrics__SelectForm__search__actions'>
             <Tooltip title='Reset query'>
               <div>
@@ -278,6 +268,22 @@ function SelectForm({
               </div>
             </Tooltip>
           </div>
+          <Button
+            fullWidth
+            key={`${requestIsPending}`}
+            color='primary'
+            variant={requestIsPending ? 'outlined' : 'contained'}
+            startIcon={
+              <Icon
+                name={requestIsPending ? 'close' : 'search'}
+                fontSize={requestIsPending ? 12 : 14}
+              />
+            }
+            className='Metrics__SelectForm__search__button'
+            onClick={requestIsPending ? handleRequestAbort : handleMetricSearch}
+          >
+            {requestIsPending ? 'Cancel' : 'Search'}
+          </Button>
         </div>
       </div>
     </ErrorBoundary>

--- a/src/src/pages/Metrics/components/SelectForm/SelectForm.tsx
+++ b/src/src/pages/Metrics/components/SelectForm/SelectForm.tsx
@@ -207,7 +207,6 @@ function SelectForm({
                 No metrics are selected
               </Text>
             )}
-            {/* Box must expand vertically if too many metrics are selected */}
             <Box
               className='Metrics__SelectForm__tags ScrollBar__hidden'
               flex={1}

--- a/src/src/pages/Params/components/SelectForm/SelectForm.scss
+++ b/src/src/pages/Params/components/SelectForm/SelectForm.scss
@@ -18,14 +18,18 @@
 }
 
 .SelectForm__tags {
-  display: flex;
   align-items: center;
-  overflow: auto;
-  max-width: calc(100vw - 40rem);
-  min-width: 15rem;
+  min-width: 12rem;
+  max-height: 3.2rem;
+
+  overflow-y: scroll;
+  scrollbar-color: auto;
+  scrollbar-width: thin;
+  overflow-x: hidden;
 
   .Badge {
-    margin-right: 0.5rem;
+    margin-right: $space-xxxs;
+    margin-bottom: 2px;
     &:last-child {
       margin-right: 20px;
     }
@@ -78,11 +82,11 @@
   width: 24px;
   background: #e8f1fc;
   border-radius: 6px;
-  display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   position: relative;
+  display: inline-flex;
   &.disabled {
     opacity: 0.5;
   }
@@ -91,12 +95,6 @@
     position: absolute;
     width: 20px;
     height: 34px;
-    background: rgba(255, 255, 255, 0.5);
-    background: linear-gradient(
-      90deg,
-      rgba(255, 255, 255, 0) 0%,
-      rgba(255, 255, 255, 1) 92%
-    );
     left: -20px;
     top: -5px;
     border-radius: 0;

--- a/src/src/pages/Params/components/SelectForm/SelectForm.tsx
+++ b/src/src/pages/Params/components/SelectForm/SelectForm.tsx
@@ -143,7 +143,7 @@ function SelectForm({
     <ErrorBoundary>
       <div className='SelectForm__container'>
         <div className='SelectForm__params__container'>
-          <Box display='flex'>
+          <Box display='flex' alignItems='center'>
             <Box
               width='100%'
               display='flex'
@@ -151,7 +151,7 @@ function SelectForm({
               alignItems='center'
             >
               <ErrorBoundary>
-                <Box display='flex' alignItems='center'>
+                <Box display='flex' alignItems='center' width='100%'>
                   <Button
                     variant='contained'
                     color='primary'
@@ -201,7 +201,7 @@ function SelectForm({
                             (tag: ISelectOption) => {
                               return (
                                 <Badge
-                                  size='large'
+                                  size='small'
                                   key={tag.label}
                                   label={tag.label}
                                   value={tag.key}
@@ -211,26 +211,30 @@ function SelectForm({
                               );
                             },
                           )}
+
+                          {selectedParamsData?.options &&
+                            selectedParamsData.options.length > 1 && (
+                              <ErrorBoundary>
+                                <Button
+                                  onClick={() => onParamsSelectChange([])}
+                                  withOnlyIcon
+                                  className={classNames(
+                                    'SelectForm__clearAll',
+                                    {
+                                      disabled: isDisabled,
+                                    },
+                                  )}
+                                  size='xSmall'
+                                  disabled={isDisabled}
+                                >
+                                  <Icon name='close' />
+                                </Button>
+                              </ErrorBoundary>
+                            )}
                         </Box>
                       </ErrorBoundary>
                     )}
                 </Box>
-                {selectedParamsData?.options &&
-                  selectedParamsData.options.length > 1 && (
-                    <ErrorBoundary>
-                      <Button
-                        onClick={() => onParamsSelectChange([])}
-                        withOnlyIcon
-                        className={classNames('SelectForm__clearAll', {
-                          disabled: isDisabled,
-                        })}
-                        size='xSmall'
-                        disabled={isDisabled}
-                      >
-                        <Icon name='close' />
-                      </Button>
-                    </ErrorBoundary>
-                  )}
               </ErrorBoundary>
             </Box>
             <Button


### PR DESCRIPTION
This is a PR for improving the run selector for Metrics (https://github.com/G-Research/fasttrackml/issues/1031). It does not look too good when the number of lines exceeds 3, but users would have to select dozens of metrics for that to happen.

## Changelog
- Added support for multiple lines of selected metrics (allow wrapping in container)
- Shrunk the selected metric badges to increase the number of possible selected metrics
- Flipped the positions of the run query bar and the selected metrics

## Screenshots
### No wrap:
![image](https://github.com/G-Research/fasttrackml-ui-aim/assets/97265671/42b79a48-cd67-4b45-b8fa-c99a92735a57)

### Wrap:
![image](https://github.com/G-Research/fasttrackml-ui-aim/assets/97265671/0bb01903-ffeb-4d32-833e-2382e0ce4e9f)