### PR TITLE
Fix "Select All" Experiments on Experiment Header

### DIFF
--- a/src/src/pages/Experiment/components/ExperimentBar/ExperimentBar.tsx
+++ b/src/src/pages/Experiment/components/ExperimentBar/ExperimentBar.tsx
@@ -32,6 +32,16 @@ function ExperimentBar({
     return name;
   }
 
+  // Selected experiments are the ones that are checked
+  const [selectedExperiments, setSelectedExperiments] = React.useState<
+    string[]
+  >(selectedExperimentNames);
+
+  // Update selected experiments in UI when selectedExperimentNames change
+  React.useEffect(() => {
+    setSelectedExperiments(selectedExperimentNames);
+  }, [selectedExperimentNames]);
+
   return (
     <ErrorBoundary>
       <div className='ExperimentBar__headerContainer'>
@@ -67,14 +77,14 @@ function ExperimentBar({
                           <Icon name={opened ? 'arrow-up' : 'arrow-down'} />
                         </Button>
 
-                        {selectedExperimentNames.length === 0 ? (
+                        {selectedExperiments.length === 0 ? (
                           <Text className='ExperimentBar__headerContainer__appBarTitleBox__text'>
                             Select Experiments
                           </Text>
                         ) : null}
 
                         <div className='ExperimentBar__headerContainer__appBarTitleBox__chipContainer'>
-                          {selectedExperimentNames.map((experimentName) => (
+                          {selectedExperiments.map((experimentName) => (
                             <Tooltip
                               key={experimentName}
                               title={experimentName}
@@ -109,7 +119,8 @@ function ExperimentBar({
                 <ExperimentSelectionPopover
                   isExperimentsLoading={isExperimentsLoading}
                   experimentsData={experimentsData}
-                  selectedExperimentNames={selectedExperimentNames}
+                  selectedExperiments={selectedExperiments}
+                  setSelectedExperiments={setSelectedExperiments}
                   getExperimentsData={getExperimentsData}
                   onSelectExperimentNamesChange={onSelectExperimentNamesChange}
                   onToggleAllExperiments={onToggleAllExperiments}

--- a/src/src/pages/Experiment/components/ExperimentSelectionPopover/ExperimentSelectionPopover.d.ts
+++ b/src/src/pages/Experiment/components/ExperimentSelectionPopover/ExperimentSelectionPopover.d.ts
@@ -2,9 +2,10 @@ import { IExperimentData } from 'modules/core/api/experimentsApi/types';
 
 export interface IExperimentSelectionPopoverProps {
   experimentsData: IExperimentData[] | null;
-  selectedExperimentNames: string[];
+  selectedExperiments: string[];
   isExperimentsLoading: boolean;
   getExperimentsData: () => void;
+  setSelectedExperiments: (selectedExperiments: string[]) => void;
   onSelectExperimentNamesChange: (experimentName: string) => void;
   onToggleAllExperiments: (experimentNames: string[]) => void;
 }


### PR DESCRIPTION
Fix for an issue with the experiment header where the "Select All" button was refreshing the selected experiments behind the scenes but not accurately displaying the currently selected experiments, making it impossible to deselect all experiments in one go.

Issue was a React render problem, fixed it by just storing the relevant UI state in the `ExperimentBar` component and passing it down to the `ExperimentSelectionPopover` which handles the experiment switching for the UI.