### PR TITLE
Project Params Hotfix

### DIFF
--- a/src/src/services/api/projects/projectsService.ts
+++ b/src/src/services/api/projects/projectsService.ts
@@ -24,14 +24,17 @@ function fetchActivityData(): IApiRequest<any> {
 
 function getProjectParams(
   sequences: string[] = ['metric'],
+  selectedExperimentNames: string[] = [],
 ): IApiRequest<IProjectParamsMetrics> {
-  const query = sequences.reduce(
-    (acc: string, sequence: string, index: number) => {
+  const query =
+    sequences.reduce((acc: string, sequence: string, index: number) => {
       acc += `${index === 0 ? '?' : '&'}sequence=${sequence}`;
       return acc;
-    },
-    '',
-  );
+    }, '') +
+    selectedExperimentNames.reduce((acc: string, experimentName: string) => {
+      acc += `&experiment_names=${experimentName}`;
+      return acc;
+    }, '');
   return API.get<IProjectParamsMetrics>(endpoints.GET_PROJECTS_PARAMS + query);
 }
 

--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -559,8 +559,10 @@ function createAppModel(appConfig: IAppInitialConfig) {
     }
 
     function fetchProjectParamsAndUpdateState() {
+      const selectedExperimentNames =
+        model.getState()?.config?.select.selectedExperimentNames;
       projectsService
-        .getProjectParams(['metric'])
+        .getProjectParams(['metric'], selectedExperimentNames)
         .call()
         .then((data) => {
           const advancedSuggestions: Record<any, any> = getAdvancedSuggestion(
@@ -2232,9 +2234,11 @@ function createAppModel(appConfig: IAppInitialConfig) {
           setModelDefaultAppConfigData();
         }
 
+        const selectedExperimentNames =
+          model.getState()?.config?.select?.selectedExperimentNames;
         const liveUpdateState = model.getState()?.config.liveUpdate;
         projectsService
-          .getProjectParams(['metric'])
+          .getProjectParams(['metric'], selectedExperimentNames)
           .call()
           .then((data) => {
             model.setState({
@@ -3281,8 +3285,10 @@ function createAppModel(appConfig: IAppInitialConfig) {
             chartPanelRef: { current: null },
           };
         }
+        const selectedExperimentNames =
+          model.getState()?.config?.select?.selectedExperimentNames;
         projectsService
-          .getProjectParams(['metric'])
+          .getProjectParams(['metric'], selectedExperimentNames)
           .call()
           .then((data) => {
             model.setState({
@@ -4894,8 +4900,10 @@ function createAppModel(appConfig: IAppInitialConfig) {
         }
         const liveUpdateState = model.getState()?.config?.liveUpdate;
 
+        const selectedExperimentNames =
+          model.getState()?.config?.select.selectedExperimentNames;
         projectsService
-          .getProjectParams(['metric'])
+          .getProjectParams(['metric'], selectedExperimentNames)
           .call()
           .then((data: IProjectParamsMetrics) => {
             model.setState({

--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -2018,6 +2018,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
         onSelectExperimentNamesChange(experimentName: string): void {
           // Handle experiment change, then re-fetch metrics data
           onSelectExperimentNamesChange({ experimentName, model });
+          fetchProjectParamsAndUpdateState();
           getMetricsData(true, true).call();
         },
         onToggleAllExperiments(experimentNames: string[]): void {


### PR DESCRIPTION
Hotfix for `project/params` endpoint not receiving `experiment_names`. This will be changed in the future to `experiment_ids` instead: https://github.com/G-Research/fasttrackml/issues/1098

Backend PRs: https://github.com/G-Research/fasttrackml/pull/1096, https://github.com/G-Research/fasttrackml/pull/1097