### PR TITLE
Fix project/params fetch for Params tab

### DIFF
--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -3286,6 +3286,24 @@ function createAppModel(appConfig: IAppInitialConfig) {
             chartPanelRef: { current: null },
           };
         }
+        model.setState({ ...state });
+        if (!appId) {
+          setModelDefaultAppConfigData();
+        }
+        fetchProjectParamsAndUpdateState();
+
+        const liveUpdateState = model.getState()?.config?.liveUpdate;
+
+        if (liveUpdateState?.enabled) {
+          liveUpdateInstance = new LiveUpdateService(
+            appName,
+            updateData,
+            liveUpdateState.delay,
+          );
+        }
+      }
+
+      function fetchProjectParamsAndUpdateState() {
         const selectedExperimentNames =
           model.getState()?.config?.select?.selectedExperimentNames;
         projectsService
@@ -3299,19 +3317,6 @@ function createAppModel(appConfig: IAppInitialConfig) {
               },
             });
           });
-        model.setState({ ...state });
-        if (!appId) {
-          setModelDefaultAppConfigData();
-        }
-        const liveUpdateState = model.getState()?.config?.liveUpdate;
-
-        if (liveUpdateState?.enabled) {
-          liveUpdateInstance = new LiveUpdateService(
-            appName,
-            updateData,
-            liveUpdateState.delay,
-          );
-        }
       }
 
       function updateData(newData: IRun<IParamTrace>[]): void {
@@ -4717,6 +4722,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
           onSelectExperimentNamesChange(experimentName: string): void {
             // Handle experiment change, then re-fetch params data
             onSelectExperimentNamesChange({ experimentName, model });
+            fetchProjectParamsAndUpdateState();
             getParamsData(true, true).call();
           },
           onToggleAllExperiments(experimentNames: string[]): void {


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/1110.
Fetch `projects/param`s on initialize of params tab and every time the experiments header selection changes.