### PR TITLE
Fix projects/params poll

### DIFF
--- a/src/src/pages/Metrics/MetricsContainer.tsx
+++ b/src/src/pages/Metrics/MetricsContainer.tsx
@@ -63,6 +63,13 @@ function MetricsContainer(): React.FunctionComponentElement<React.ReactNode> {
   }, [metricsData?.rawData]);
 
   React.useEffect(() => {
+    const pollingTimer = setInterval(() => {
+      metricAppModel.fetchProjectParamsAndUpdateState();
+    }, 30000);
+    return () => clearInterval(pollingTimer);
+  }, []);
+
+  React.useEffect(() => {
     metricAppModel.initialize(route.params.appId);
     let appRequestRef: IApiRequest<void>;
     let metricsRequestRef: IApiRequest<void>;

--- a/src/src/pages/Params/ParamsContainer.tsx
+++ b/src/src/pages/Params/ParamsContainer.tsx
@@ -65,6 +65,13 @@ function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
   }, [paramsData?.rawData]);
 
   React.useEffect(() => {
+    const pollingTimer = setInterval(() => {
+      paramsAppModel.fetchProjectParamsAndUpdateState();
+    }, 30000);
+    return () => clearInterval(pollingTimer);
+  }, []);
+
+  React.useEffect(() => {
     paramsAppModel.initialize(route.params.appId);
     let appRequestRef: IApiRequest<void>;
     let paramsRequestRef: IApiRequest<void>;

--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -558,7 +558,6 @@ function createAppModel(appConfig: IAppInitialConfig) {
     }
 
     function fetchProjectParamsAndUpdateState() {
-      console.log('FETCHING metrics proj/params');
       const selectedExperimentNames =
         model.getState()?.config?.select.selectedExperimentNames;
       projectsService
@@ -4632,6 +4631,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
         onShuffleChange,
         deleteRuns,
         archiveRuns,
+        fetchProjectParamsAndUpdateState,
       };
 
       if (grouping) {

--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -545,7 +545,6 @@ function createAppModel(appConfig: IAppInitialConfig) {
 
       // fetch project params now and update every 30s
       fetchProjectParamsAndUpdateState();
-      setInterval(fetchProjectParamsAndUpdateState, 30000);
 
       const liveUpdateState = model.getState()?.config?.liveUpdate;
 
@@ -559,6 +558,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
     }
 
     function fetchProjectParamsAndUpdateState() {
+      console.log('FETCHING metrics proj/params');
       const selectedExperimentNames =
         model.getState()?.config?.select.selectedExperimentNames;
       projectsService
@@ -1951,6 +1951,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
       destroy,
       deleteRuns,
       archiveRuns,
+      fetchProjectParamsAndUpdateState,
     };
 
     if (grouping) {


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/1111.
Now polling for `projects/params`  in metrics tab and in params tab and stop polling when we are not in these tabs.