### PR TITLE
Fix search query enter bug

### DIFF
--- a/src/src/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/src/components/AutocompleteInput/AutocompleteInput.tsx
@@ -47,7 +47,21 @@ function AutocompleteInput({
         monacoConfig.theme.config,
       );
       monaco.editor.setTheme(monacoConfig.theme.name);
+
+      // Prevent editor from adding spaces on enter after an open parenthesis
+      monaco.languages.setLanguageConfiguration('python', {
+        onEnterRules: [
+          {
+            beforeText: new RegExp(/(\s*\(\s*)$/),
+            action: {
+              indentAction: monaco.languages.IndentAction.None,
+              appendText: '',
+            },
+          },
+        ],
+      });
     }
+
     const onResize = _.debounce(() => {
       setContainerWidth(window.innerWidth);
     }, 500);


### PR DESCRIPTION
This is a fix for https://github.com/G-Research/fasttrackml/issues/375 which is a problem with the `monaco-editor` configuration. I simply added a rule to prevent adding tabs (as modifying the `monacoConfig.ts` directly was not working).

This also fixes the same issue when pressing enter after or in between some whitespace.