### PR TITLE
Show only the visible columns in Manage Columns popover

### DIFF
--- a/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -21,6 +21,7 @@ import { IManageColumnsPopoverProps } from './ManageColumns';
 
 import './ManageColumnsPopover.scss';
 
+let softHidden: string[] = [];
 const initialData = {
   columns: {
     left: {
@@ -72,6 +73,15 @@ function ManageColumnsPopover({
       );
     }
   };
+
+  function toggleShoftHidden(key: string) {
+    if (softHidden.includes(key)) {
+      const index = softHidden.indexOf(key);
+      softHidden.splice(index);
+    } else {
+      softHidden.push(key);
+    }
+  }
 
   function onDragStart(result: any) {
     setDraggingItemId(result.draggableId);
@@ -171,13 +181,20 @@ function ManageColumnsPopover({
   React.useEffect(() => {
     const newState = { ...state };
     const leftList = columnsData.filter(
-      (item: ITableColumn) => item.pin === 'left',
+      (item: ITableColumn) =>
+        item.pin === 'left' &&
+        (!item.isHidden || softHidden.includes(item.key)),
     );
     const rightList = columnsData.filter(
-      (item: ITableColumn) => item.pin === 'right',
+      (item: ITableColumn) =>
+        item.pin === 'right' &&
+        (!item.isHidden || softHidden.includes(item.key)),
     );
     const middleList = columnsData.filter(
-      (item: ITableColumn) => item.pin !== 'left' && item.pin !== 'right',
+      (item: ITableColumn) =>
+        item.pin !== 'left' &&
+        item.pin !== 'right' &&
+        (!item.isHidden || softHidden.includes(item.key)),
     );
     newState.columns.left.list = leftList;
     newState.columns.middle.list = middleList;
@@ -285,15 +302,16 @@ function ManageColumnsPopover({
                             popoverWidth={popoverWidth}
                             appName={appName}
                             isHidden={isColumnHidden(column.key)}
-                            onClick={() =>
+                            onClick={() => {
+                              toggleShoftHidden(column.key);
                               onColumnsVisibilityChange(
                                 hiddenColumns?.includes(column.key)
                                   ? hiddenColumns?.filter(
                                       (col: string) => col !== column.key,
                                     )
                                   : hiddenColumns?.concat([column.key]),
-                              )
-                            }
+                              );
+                            }}
                             draggingItemId={draggingItemId}
                           />
                         ),
@@ -341,15 +359,16 @@ function ManageColumnsPopover({
                             hasSearchableItems
                             searchKey={searchKey}
                             isHidden={isColumnHidden(column.key)}
-                            onClick={() =>
+                            onClick={() => {
+                              toggleShoftHidden(column.key);
                               onColumnsVisibilityChange(
                                 hiddenColumns?.includes(column.key)
                                   ? hiddenColumns?.filter(
                                       (col: string) => col !== column.key,
                                     )
                                   : hiddenColumns?.concat([column.key]),
-                              )
-                            }
+                              );
+                            }}
                             draggingItemId={draggingItemId}
                           />
                         ),
@@ -383,15 +402,16 @@ function ManageColumnsPopover({
                               appName={appName}
                               popoverWidth={popoverWidth}
                               isHidden={isColumnHidden(column.key)}
-                              onClick={() =>
+                              onClick={() => {
+                                toggleShoftHidden(column.key);
                                 onColumnsVisibilityChange(
                                   hiddenColumns.includes(column.key)
                                     ? hiddenColumns.filter(
                                         (col: string) => col !== column.key,
                                       )
                                     : hiddenColumns.concat([column.key]),
-                                )
-                              }
+                                );
+                              }}
                               draggingItemId={draggingItemId}
                             />
                           );

--- a/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -74,13 +74,10 @@ function ManageColumnsPopover({
     }
   };
 
-  function toggleShoftHidden(key: string) {
-    if (softHidden.includes(key)) {
-      const index = softHidden.indexOf(key);
-      softHidden.splice(index);
-    } else {
-      softHidden.push(key);
-    }
+  function toggleSoftHidden(key: string) {
+    softHidden.includes(key)
+      ? softHidden.splice(softHidden.indexOf(key), 1)
+      : softHidden.push(key);
   }
 
   function onDragStart(result: any) {
@@ -303,7 +300,7 @@ function ManageColumnsPopover({
                             appName={appName}
                             isHidden={isColumnHidden(column.key)}
                             onClick={() => {
-                              toggleShoftHidden(column.key);
+                              toggleSoftHidden(column.key);
                               onColumnsVisibilityChange(
                                 hiddenColumns?.includes(column.key)
                                   ? hiddenColumns?.filter(
@@ -360,7 +357,7 @@ function ManageColumnsPopover({
                             searchKey={searchKey}
                             isHidden={isColumnHidden(column.key)}
                             onClick={() => {
-                              toggleShoftHidden(column.key);
+                              toggleSoftHidden(column.key);
                               onColumnsVisibilityChange(
                                 hiddenColumns?.includes(column.key)
                                   ? hiddenColumns?.filter(
@@ -403,7 +400,7 @@ function ManageColumnsPopover({
                               popoverWidth={popoverWidth}
                               isHidden={isColumnHidden(column.key)}
                               onClick={() => {
-                                toggleShoftHidden(column.key);
+                                toggleSoftHidden(column.key);
                                 onColumnsVisibilityChange(
                                   hiddenColumns.includes(column.key)
                                     ? hiddenColumns.filter(


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/1153.
Changes to just show the visible columns in the Manage Columns popover list, introduce another layer of visibility to hide and show again items of the list.