### PR TITLE
Set experiment_names in search/run

### DIFF
--- a/src/src/services/models/explorer/createAppModel.ts
+++ b/src/src/services/models/explorer/createAppModel.ts
@@ -3451,7 +3451,15 @@ function createAppModel(appConfig: IAppInitialConfig) {
 
         const configData = { ...model.getState()?.config };
         const query = getQueryStringFromSelect(configData?.select, true);
-        runsRequestRef = runsService.getRunsData(query);
+        const selectedExperimentNames = getSelectedExperiments().map(
+          (e) => e.name,
+        );
+        runsRequestRef = runsService.getRunsData(
+          query,
+          undefined,
+          undefined,
+          selectedExperimentNames,
+        );
         setRequestProgress(model);
         return {
           call: async () => {
@@ -5953,7 +5961,15 @@ function createAppModel(appConfig: IAppInitialConfig) {
 
         const configData = { ...model.getState()?.config };
         const query = getQueryStringFromSelect(configData?.select, true);
-        runsRequestRef = runsService.getRunsData(query);
+        const selectedExperimentNames = getSelectedExperiments().map(
+          (e) => e.name,
+        );
+        runsRequestRef = runsService.getRunsData(
+          query,
+          undefined,
+          undefined,
+          selectedExperimentNames,
+        );
         setRequestProgress(model);
         return {
           call: async () => {

--- a/src/src/utils/app/getQueryStringFromSelect.ts
+++ b/src/src/utils/app/getQueryStringFromSelect.ts
@@ -54,19 +54,11 @@ export default function getQueryStringFromSelect(
         : '';
     }
 
-    const selectedExperiments = getSelectedExperiments();
-
-    const experimentNames = `run.experiment in ["${selectedExperiments
-      .map((e) => e.name)
-      .join('", "')}"]`;
-
     if (simpleInput && selections) {
       query = `${simpleInput} and ${selections}`;
     } else {
       query = `${simpleInput}${selections}`;
     }
-
-    query = query ? `${query} and ${experimentNames}` : experimentNames;
   }
   return excludeMetrics ? query.trim() || '' : query.trim() || '()';
 }


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/1193.
Remove passing experiment names into the query of `search/run` and pass them into `experiment_names` for params and scatter tabs.