### PR TITLE
Metric Tooltip Rounding

### DIFF
--- a/src/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/src/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -59,6 +59,17 @@ const PopoverContent = React.forwardRef(function PopoverContent(
     [tooltipAppearance],
   );
 
+  const roundToSignificantDigits = (value: number, sig: number = 5) => {
+    if (value === 0) {
+      return 0;
+    }
+
+    const power = sig - Math.ceil(Math.log10(Math.abs(value)));
+    const magnitude = Math.pow(10, power);
+    const shifted = Math.round(value * magnitude);
+    return shifted / magnitude;
+  };
+
   function renderPopoverHeader(): React.ReactNode {
     switch (chartType) {
       case ChartTypeEnum.LineChart: {
@@ -75,7 +86,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                     {contextToString(context)}
                   </Text>
                   <Text component='p' className='PopoverContent__axisValue'>
-                    {focusedState?.yValue}
+                    {roundToSignificantDigits(Number(focusedState?.yValue))}
                   </Text>
                 </span>
               </div>

--- a/src/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/src/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -138,7 +138,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 {context || null}
               </div>
               <div className='PopoverContent__value'>
-                Value: {focusedState?.yValue}
+                Value: {roundToSignificantDigits(Number(focusedState?.yValue))}
               </div>
             </div>
           </ErrorBoundary>
@@ -179,7 +179,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 <Text>Y: </Text>
                 <span className='PopoverContent__headerValue'>
                   <Text component='p' className='PopoverContent__axisValue'>
-                    {focusedState?.yValue}
+                    {roundToSignificantDigits(Number(focusedState?.yValue))}
                   </Text>
                 </span>
               </div>
@@ -187,7 +187,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 <Text>X: </Text>
                 <span className='PopoverContent__headerValue'>
                   <Text component='p' className='PopoverContent__axisValue'>
-                    {focusedState?.xValue}
+                    {roundToSignificantDigits(Number(focusedState?.xValue))}
                   </Text>
                 </span>
               </div>

--- a/src/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/src/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -27,6 +27,7 @@ import { formatSystemMetricName } from 'utils/formatSystemMetricName';
 import getValueByField from 'utils/getValueByField';
 import { isMetricHash } from 'utils/isMetricHash';
 import { decode } from 'utils/encoder/encoder';
+import { roundToSignificantDigits } from 'utils/roundToSignificantDigits';
 
 import './PopoverContent.scss';
 
@@ -58,17 +59,6 @@ const PopoverContent = React.forwardRef(function PopoverContent(
       tooltipAppearance === TooltipAppearanceEnum.Bottom,
     [tooltipAppearance],
   );
-
-  const roundToSignificantDigits = (value: number, sig: number = 5) => {
-    if (value === 0) {
-      return 0;
-    }
-
-    const power = sig - Math.ceil(Math.log10(Math.abs(value)));
-    const magnitude = Math.pow(10, power);
-    const shifted = Math.round(value * magnitude);
-    return shifted / magnitude;
-  };
 
   function renderPopoverHeader(): React.ReactNode {
     switch (chartType) {

--- a/src/src/utils/d3/drawHoverAttributes.ts
+++ b/src/src/utils/d3/drawHoverAttributes.ts
@@ -16,6 +16,7 @@ import { IFocusedState } from 'types/services/models/metrics/metricsAppModel';
 
 import { AggregationAreaMethods } from 'utils/aggregateGroupData';
 import getRoundedValue from 'utils/roundValue';
+import { roundToSignificantDigits } from 'utils/roundToSignificantDigits';
 
 import { formatValueByAlignment } from '../formatByAlignment';
 
@@ -183,12 +184,13 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
         }
 
         const x = attrRef.current.xScale(xValue);
+        // prettier-ignore
         const left =
           x - xAxisValueWidth / 2 < 0
             ? axisLeftEdge + xAxisValueWidth / 2
             : x + axisLeftEdge + xAxisValueWidth / 2 > axisRightEdge
-            ? axisRightEdge - xAxisValueWidth / 2
-            : x + axisLeftEdge;
+              ? axisRightEdge - xAxisValueWidth / 2
+              : x + axisLeftEdge;
         const top = height - margin.bottom + 1;
 
         if (xAxisLabelNodeRef.current && xAxisValueWidth) {
@@ -235,34 +237,36 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
         const yAxisValueHeight =
           yAxisLabelNodeRef.current?.node()?.offsetHeight || 0;
         const y = attrRef.current.yScale(yValue);
+        // prettier-ignore
         const top =
           y - yAxisValueHeight / 2 < 0
             ? axisTopEdge + yAxisValueHeight / 2
             : y + axisTopEdge + yAxisValueHeight / 2 > axisBottomEdge
-            ? axisBottomEdge - yAxisValueHeight / 2
-            : y + axisTopEdge;
+              ? axisBottomEdge - yAxisValueHeight / 2
+              : y + axisTopEdge;
 
         const right = width - margin.left;
         const maxWidth = margin.left - 5;
+        const yValueRounded = roundToSignificantDigits(Number(yValue));
 
         if (yAxisLabelNodeRef.current && yAxisValueHeight) {
           // update y-axis label
           yAxisLabelNodeRef.current
-            .attr('title', yValue)
+            .attr('title', yValueRounded)
             .style('top', `${top}px`)
             .style('right', `${right}px`)
             .style('max-width', `${maxWidth}px`)
-            .text(yValue);
+            .text(yValueRounded);
         } else {
           // create y-axis label
           yAxisLabelNodeRef.current = visArea
             .append('div')
             .attr('class', 'ChartMouseValue ChartMouseValueYAxis')
-            .attr('title', yValue)
+            .attr('title', yValueRounded)
             .style('top', `${top}px`)
             .style('right', `${right}px`)
             .style('max-width', `${maxWidth}px`)
-            .text(yValue);
+            .text(yValueRounded);
         }
       }
     }

--- a/src/src/utils/roundToSignificantDigits.ts
+++ b/src/src/utils/roundToSignificantDigits.ts
@@ -1,0 +1,16 @@
+/**
+ * Rounds a number to a specified number of significant digits.
+ * @param value the number which needs to be rounded
+ * @param sig the number of significant digits
+ * @returns the rounded number
+ */
+export const roundToSignificantDigits = (value: number, sig: number = 5) => {
+  if (value === 0) {
+    return 0;
+  }
+
+  const power = sig - Math.ceil(Math.log10(Math.abs(value)));
+  const magnitude = Math.pow(10, power);
+  const shifted = Math.round(value * magnitude);
+  return shifted / magnitude;
+};


### PR DESCRIPTION
This is a PR for https://github.com/G-Research/fasttrackml/issues/1125. Note that the code differs somewhat from what's mentioned in the issue in order to cover edge cases (such as log 0).

It also adds rounding for Params and Scatters chart values, as well as the chart y-axis label as shown below:

![image](https://github.com/G-Research/fasttrackml-ui-aim/assets/97265671/fc63ab7e-889a-4de6-94ae-c1f06bd69da7)
