### PR TITLE
Dashboard E2E tests

### DIFF
--- a/src/e2e/Dashboard/DashboardContent.spec.ts
+++ b/src/e2e/Dashboard/DashboardContent.spec.ts
@@ -16,4 +16,41 @@ test.describe('Dashboard', () => {
     );
     expect(textContent).toBe('Total runs: 2');
   });
+
+  test('has two experiments', async ({ page }) => {
+    const textContent = await page.textContent('h3.ExperimentsCard__title');
+    expect(textContent).toBe('Experiments (2)');
+  });
+
+  test('Default experiment exists and has no runs', async ({ page }) => {
+    const table = await page.$('.BaseTable__body');
+    const rows = await table?.$$('.BaseTable__row');
+    expect(rows).not.toBeNull();
+
+    const firstRow = rows?.[0];
+    const experimentName = await firstRow?.$eval(
+      '.ExperimentNameBox__experimentName a',
+      (el) => el.textContent,
+    );
+    expect(experimentName).toBe('Default');
+
+    const runCount = await firstRow?.$eval('p', (el) => el.textContent);
+    expect(runCount).toBe('0');
+  });
+
+  test('generated experiment exists and has two runs', async ({ page }) => {
+    const table = await page.$('.BaseTable__body');
+    const rows = await table?.$$('.BaseTable__row');
+    expect(rows).not.toBeNull();
+
+    const secondRow = rows?.[1];
+    const experimentName = await secondRow?.$eval(
+      '.ExperimentNameBox__experimentName a',
+      (el) => el.textContent,
+    );
+    expect(experimentName).toContain('experiment-');
+
+    const runCount = await secondRow?.$eval('p', (el) => el.textContent);
+    expect(runCount).toBe('2');
+  });
 });

--- a/src/e2e/Dashboard/DashboardContent.spec.ts
+++ b/src/e2e/Dashboard/DashboardContent.spec.ts
@@ -53,4 +53,22 @@ test.describe('Dashboard', () => {
     const runCount = await secondRow?.$eval('p', (el) => el.textContent);
     expect(runCount).toBe('2');
   });
+
+  test('experiment search bar filters table experiments', async ({ page }) => {
+    const searchInput = await page.$('.SearchBar input#search');
+    await searchInput?.fill('Default');
+    const value = await searchInput?.inputValue();
+    expect(value).toBe('Default');
+
+    const table = await page.$('.BaseTable__body');
+    const rows = await table?.$$('.BaseTable__row');
+    expect(rows?.length).toBe(1);
+
+    const firstRow = rows?.[0];
+    const experimentName = await firstRow?.$eval(
+      '.ExperimentNameBox__experimentName a',
+      (el) => el.textContent,
+    );
+    expect(experimentName).toBe('Default');
+  });
 });

--- a/src/e2e/Dashboard/DashboardContent.spec.ts
+++ b/src/e2e/Dashboard/DashboardContent.spec.ts
@@ -131,7 +131,7 @@ test.describe('Dashboard', () => {
 
     await page.waitForLoadState('networkidle');
 
-    const textBox = await page.locator('.view-lines.monaco-mouse-cursor-text');
+    const textBox = page.locator('.view-lines.monaco-mouse-cursor-text');
 
     const textContent = await textBox.evaluate((el) => el.innerText);
 
@@ -139,5 +139,47 @@ test.describe('Dashboard', () => {
     const trimmedTextContent = textContent.replace(/\s/g, '');
 
     expect(trimmedTextContent).toContain(expectedText);
+  });
+
+  test("clicking on the Default experiment link redirects to the experiment's page", async ({
+    page,
+  }) => {
+    const table = await page.$('.BaseTable__body');
+    const rows = await table?.$$('.BaseTable__row');
+    expect(rows).not.toBeNull();
+
+    const firstRow = rows?.[0];
+    const experimentLink = await firstRow?.$('a');
+    await experimentLink?.click();
+
+    await page.waitForLoadState('networkidle');
+
+    const experimentNameElement = page.locator(
+      '.ExperimentHeader__headerContainer__appBarTitleBox__container',
+    );
+    const experimentName = await experimentNameElement.innerText();
+
+    expect(experimentName).toContain('Default');
+  });
+
+  test("clicking on the generated experiment link redirects to the experiment's page", async ({
+    page,
+  }) => {
+    const table = await page.$('.BaseTable__body');
+    const rows = await table?.$$('.BaseTable__row');
+    expect(rows).not.toBeNull();
+
+    const secondRow = rows?.[1];
+    const experimentLink = await secondRow?.$('a');
+    await experimentLink?.click();
+
+    await page.waitForLoadState('networkidle');
+
+    const experimentNameElement = page.locator(
+      '.ExperimentHeader__headerContainer__appBarTitleBox__container',
+    );
+    const experimentName = await experimentNameElement.innerText();
+
+    expect(experimentName).toContain('experiment-');
   });
 });

--- a/src/e2e/Dashboard/DashboardLogic.spec.ts
+++ b/src/e2e/Dashboard/DashboardLogic.spec.ts
@@ -13,23 +13,40 @@ test.describe('Dashboard', () => {
 
   test('active runs link redirects correctly', async ({ page }) => {
     await page.getByText('Active Runs').click({ force: true });
+    await page.waitForLoadState('networkidle');
 
-    await page.getByRole('code', { name: 'runs.active == True' });
+    const expectedText = 'run.active==True';
+    const textBox = await page.locator('.view-lines.monaco-mouse-cursor-text');
+    const textContent = await textBox.evaluate((el) => el.innerText);
+    const trimmedTextContent = textContent.replace(/\s/g, '');
+
+    expect(trimmedTextContent).toContain(expectedText);
   });
 
   test('archived runs link redirects correctly', async ({ page }) => {
     await page.getByText('Archived Runs').click({ force: true });
+    await page.waitForLoadState('networkidle');
 
-    await page.getByRole('code', { name: 'runs.active == False' });
+    const expectedText = 'run.archived==True';
+    const textBox = await page.locator('.view-lines.monaco-mouse-cursor-text');
+    const textContent = await textBox.evaluate((el) => el.innerText);
+    const trimmedTextContent = textContent.replace(/\s/g, '');
+
+    expect(trimmedTextContent).toContain(expectedText);
   });
 
   test("last week's runs link redirects correctly", async ({ page }) => {
     await page.getByText("Last Week's Runs").click({ force: true });
+    await page.waitForLoadState('networkidle');
 
     // The text varies depending on the current date:
     // Example: datetime(2024, 6, 3) <= run.created_at < datetime(2024, 6, 10)
-    await page.getByRole('code', {
-      name: /datetime\(\d+, \d+, \d+\) <= run\.created_at < datetime\(\d+, \d+, \d+\)/,
-    });
+    const queryRegex =
+      /datetime\(\d+,\d+,\d+\)<=run\.created_at<datetime\(\d+,\d+,\d+\)/;
+    const textBox = await page.locator('.view-lines.monaco-mouse-cursor-text');
+    const textContent = await textBox.evaluate((el) => el.innerText);
+    const trimmedTextContent = textContent.replace(/\s/g, '');
+
+    expect(queryRegex.test(trimmedTextContent)).toBeTruthy();
   });
 });

--- a/src/e2e/Dashboard/DashboardLogic.spec.ts
+++ b/src/e2e/Dashboard/DashboardLogic.spec.ts
@@ -16,7 +16,7 @@ test.describe('Dashboard', () => {
     await page.waitForLoadState('networkidle');
 
     const expectedText = 'run.active==True';
-    const textBox = await page.locator('.view-lines.monaco-mouse-cursor-text');
+    const textBox = page.locator('.view-lines.monaco-mouse-cursor-text');
     const textContent = await textBox.evaluate((el) => el.innerText);
     const trimmedTextContent = textContent.replace(/\s/g, '');
 
@@ -28,7 +28,7 @@ test.describe('Dashboard', () => {
     await page.waitForLoadState('networkidle');
 
     const expectedText = 'run.archived==True';
-    const textBox = await page.locator('.view-lines.monaco-mouse-cursor-text');
+    const textBox = page.locator('.view-lines.monaco-mouse-cursor-text');
     const textContent = await textBox.evaluate((el) => el.innerText);
     const trimmedTextContent = textContent.replace(/\s/g, '');
 
@@ -43,7 +43,7 @@ test.describe('Dashboard', () => {
     // Example: datetime(2024, 6, 3) <= run.created_at < datetime(2024, 6, 10)
     const queryRegex =
       /datetime\(\d+,\d+,\d+\)<=run\.created_at<datetime\(\d+,\d+,\d+\)/;
-    const textBox = await page.locator('.view-lines.monaco-mouse-cursor-text');
+    const textBox = page.locator('.view-lines.monaco-mouse-cursor-text');
     const textContent = await textBox.evaluate((el) => el.innerText);
     const trimmedTextContent = textContent.replace(/\s/g, '');
 

--- a/src/playwright.config.ts
+++ b/src/playwright.config.ts
@@ -42,11 +42,6 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
     /* Test against mobile viewports. */
     // {
     //   name: 'Mobile Chrome',

--- a/src/src/components/ContributionsFeed/ContributionsFeed.scss
+++ b/src/src/components/ContributionsFeed/ContributionsFeed.scss
@@ -13,4 +13,8 @@
       margin-bottom: $space-sm;
     }
   }
+  &__load-more {
+    margin-top: $space-sm;
+    padding: 0 $space-sm;
+  }
 }

--- a/src/src/components/ContributionsFeed/ContributionsFeed.tsx
+++ b/src/src/components/ContributionsFeed/ContributionsFeed.tsx
@@ -46,6 +46,7 @@ function ContributionsFeed({
 
           {fetchedCount < totalRunsCount - archivedRunsCount! ? (
             <Button
+              className='ContributionsFeed__load-more'
               variant='outlined'
               fullWidth
               size='small'

--- a/src/src/pages/Dashboard/components/DashboardContributionsFeed/useDashboardContributionsFeed.ts
+++ b/src/src/pages/Dashboard/components/DashboardContributionsFeed/useDashboardContributionsFeed.ts
@@ -103,6 +103,9 @@ function useDashboardContributionsFeed() {
 
   function loadMore(): void {
     if (contributionsFeedStore.data && !contributionsFeedStore.loading) {
+      if (data.length <= 0) {
+        return;
+      }
       engine.fetchContributionsFeed({
         limit: 25,
         exclude_params: true,


### PR DESCRIPTION
These are E2E tests related to the Dashboard (https://github.com/G-Research/fasttrackml/issues/1274).

`k6_load.js` must be executed on an empty database for these tests to pass. Tests can be executed in dev by running `npx playwright test` on the `src` directory.

Note that some of the tests (~10%) are flaky, simply because of the parallelization. The tests ultimately do pass when executed in the pipeline.