### PR TITLE
Toggle all params and all metrics on ManageColumnsPopover

### DIFF
--- a/src/src/components/ChartPanel/ChartPanel.tsx
+++ b/src/src/components/ChartPanel/ChartPanel.tsx
@@ -205,7 +205,7 @@ const ChartPanel = React.forwardRef(function ChartPanel(
                         tooltipContent={props?.tooltip?.content || {}}
                         tooltipAppearance={props?.tooltip?.appearance}
                         focusedState={props.focusedState}
-                        alignmentConfig={props.alignmentConfigs![0]}
+                        alignmentConfig={props.alignmentConfigs?.[0]}
                         selectOptions={props.selectOptions}
                         onChangeTooltip={props.onChangeTooltip}
                       />

--- a/src/src/config/enums/tableEnums.ts
+++ b/src/src/config/enums/tableEnums.ts
@@ -19,5 +19,9 @@ enum HideColumnsEnum {
   HideSystemMetrics = 'Hide System Metrics',
   ShowSystemMetrics = 'Show System Metrics',
   All = 'All',
+  HideMetrics = 'Hide Metrics',
+  ShowMetrics = 'Show Metrics',
+  HideParams = 'Hide Params',
+  ShowParams = 'Show Params',
 }
 export { RowHeightEnum, HideRowsEnum, ResizeModeEnum, HideColumnsEnum };

--- a/src/src/pages/Metrics/components/Table/HideColumnsPopover/HideColumnsPopover.tsx
+++ b/src/src/pages/Metrics/components/Table/HideColumnsPopover/HideColumnsPopover.tsx
@@ -53,7 +53,7 @@ function HideColumnsPopover({
         }}
         anchor={({ onAnchorClick, opened }) => (
           <Tooltip
-            title='Toggle hiding unselected columns by default'
+            title='Improve table performance by automatically hiding unselected columns'
             placement='top'
           >
             <div>

--- a/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import { List, AutoSizer } from 'react-virtualized';
 import _ from 'lodash-es';
 
 import { Divider, InputBase } from '@material-ui/core';
@@ -53,6 +54,8 @@ function ManageColumnsPopover({
   const [draggingItemId, setDraggingItemId] = React.useState<string>('');
   const [popoverWidth, setPopoverWidth] = React.useState(800);
   const ref = React.useRef<HTMLDivElement | null>(null);
+
+  const VIRTUAL_COLUMN_THRESHOLD = 100; // If exceeded, use virtualized list
 
   const onResize = _.debounce(() => {
     onPopoverWidthChange();
@@ -371,7 +374,8 @@ function ManageColumnsPopover({
                       ref={provided.innerRef}
                       {...provided.droppableProps}
                     >
-                      {state.columns.middle.list.length < 50 ? (
+                      {state.columns.middle.list.length <
+                      VIRTUAL_COLUMN_THRESHOLD ? (
                         state.columns.middle.list.map(
                           (column: ITableColumn, index: number) => (
                             <ColumnItem
@@ -516,11 +520,9 @@ function ManageColumnsPopover({
                 <Button
                   variant='text'
                   size='xSmall'
-                  onClick={() => {
-                    console.log('columnsData: ', columnsData);
-                    console.log('hiddenColumns: ', hiddenColumns);
-                    // onColumnsVisibilityChange(HideColumnsEnum.All);
-                  }}
+                  onClick={() =>
+                    onColumnsVisibilityChange(HideColumnsEnum.ShowParams)
+                  }
                 >
                   <Icon name='eye-show-outline' color='#1473e6' />
                   <Text size={12} tint={100}>
@@ -532,9 +534,7 @@ function ManageColumnsPopover({
                   variant='text'
                   size='xSmall'
                   onClick={() => {
-                    console.log('columnsData: ', columnsData);
-                    console.log('hiddenColumns: ', hiddenColumns);
-                    // onColumnsVisibilityChange(HideColumnsEnum.All);
+                    onColumnsVisibilityChange(HideColumnsEnum.HideParams);
                   }}
                 >
                   <Icon name='eye-outline-hide' />
@@ -546,9 +546,7 @@ function ManageColumnsPopover({
                   variant='text'
                   size='xSmall'
                   onClick={() => {
-                    console.log('columnsData: ', columnsData);
-                    console.log('hiddenColumns: ', hiddenColumns);
-                    // onColumnsVisibilityChange(HideColumnsEnum.All);
+                    onColumnsVisibilityChange(HideColumnsEnum.ShowMetrics);
                   }}
                 >
                   <Icon name='eye-show-outline' color='#1473e6' />
@@ -561,9 +559,7 @@ function ManageColumnsPopover({
                   variant='text'
                   size='xSmall'
                   onClick={() => {
-                    console.log('columnsData: ', columnsData);
-                    console.log('hiddenColumns: ', hiddenColumns);
-                    // onColumnsVisibilityChange(HideColumnsEnum.All);
+                    onColumnsVisibilityChange(HideColumnsEnum.HideMetrics);
                   }}
                 >
                   <Icon name='eye-outline-hide' />

--- a/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -245,6 +245,33 @@ function ManageColumnsPopover({
     );
   }, [appName, hiddenColumns, state]);
 
+  function generateRowRenderer(columnList: ITableColumn[]) {
+    const rowRenderer = ({ index, key }: { index: number; key: string }) => {
+      const column = columnList[index];
+      return (
+        <ColumnItem
+          key={`${column.key}-${index}`}
+          data={column.key}
+          label={column.label ?? column.key}
+          index={index}
+          popoverWidth={popoverWidth}
+          appName={appName}
+          isHidden={isColumnHidden(column.key)}
+          onClick={() => {
+            toggleSoftHidden(column.key);
+            onColumnsVisibilityChange(
+              hiddenColumns?.includes(column.key)
+                ? hiddenColumns?.filter((col: string) => col !== column.key)
+                : hiddenColumns?.concat([column.key]),
+            );
+          }}
+          draggingItemId={draggingItemId}
+        />
+      );
+    };
+    return rowRenderer;
+  }
+
   return (
     <ErrorBoundary>
       <ControlPopover
@@ -344,31 +371,47 @@ function ManageColumnsPopover({
                       ref={provided.innerRef}
                       {...provided.droppableProps}
                     >
-                      {state.columns.middle.list.map(
-                        (column: ITableColumn, index: number) => (
-                          <ColumnItem
-                            key={`${column.key}-${index}`}
-                            data={column.key}
-                            label={column.label ?? column.key}
-                            index={index}
-                            appName={appName}
-                            popoverWidth={popoverWidth}
-                            hasSearchableItems
-                            searchKey={searchKey}
-                            isHidden={isColumnHidden(column.key)}
-                            onClick={() => {
-                              toggleSoftHidden(column.key);
-                              onColumnsVisibilityChange(
-                                hiddenColumns?.includes(column.key)
-                                  ? hiddenColumns?.filter(
-                                      (col: string) => col !== column.key,
-                                    )
-                                  : hiddenColumns?.concat([column.key]),
-                              );
-                            }}
-                            draggingItemId={draggingItemId}
-                          />
-                        ),
+                      {state.columns.middle.list.length < 50 ? (
+                        state.columns.middle.list.map(
+                          (column: ITableColumn, index: number) => (
+                            <ColumnItem
+                              key={`${column.key}-${index}`}
+                              data={column.key}
+                              label={column.label ?? column.key}
+                              index={index}
+                              appName={appName}
+                              popoverWidth={popoverWidth}
+                              hasSearchableItems
+                              searchKey={searchKey}
+                              isHidden={isColumnHidden(column.key)}
+                              onClick={() => {
+                                toggleSoftHidden(column.key);
+                                onColumnsVisibilityChange(
+                                  hiddenColumns?.includes(column.key)
+                                    ? hiddenColumns?.filter(
+                                        (col: string) => col !== column.key,
+                                      )
+                                    : hiddenColumns?.concat([column.key]),
+                                );
+                              }}
+                              draggingItemId={draggingItemId}
+                            />
+                          ),
+                        )
+                      ) : (
+                        <AutoSizer>
+                          {({ height, width }) => (
+                            <List
+                              height={height}
+                              rowCount={state.columns.middle.list.length}
+                              rowHeight={30}
+                              width={width}
+                              rowRenderer={generateRowRenderer(
+                                state.columns.middle.list,
+                              )}
+                            />
+                          )}
+                        </AutoSizer>
                       )}
                       {provided.placeholder}
                     </div>

--- a/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/src/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -470,7 +470,64 @@ function ManageColumnsPopover({
                     />
                   </>
                 )}
+                <Button
+                  variant='text'
+                  size='xSmall'
+                  onClick={() => {
+                    console.log('columnsData: ', columnsData);
+                    console.log('hiddenColumns: ', hiddenColumns);
+                    // onColumnsVisibilityChange(HideColumnsEnum.All);
+                  }}
+                >
+                  <Icon name='eye-show-outline' color='#1473e6' />
+                  <Text size={12} tint={100}>
+                    {HideColumnsEnum.ShowParams}
+                  </Text>
+                </Button>
 
+                <Button
+                  variant='text'
+                  size='xSmall'
+                  onClick={() => {
+                    console.log('columnsData: ', columnsData);
+                    console.log('hiddenColumns: ', hiddenColumns);
+                    // onColumnsVisibilityChange(HideColumnsEnum.All);
+                  }}
+                >
+                  <Icon name='eye-outline-hide' />
+                  <Text size={12} tint={100}>
+                    {HideColumnsEnum.HideParams}
+                  </Text>
+                </Button>
+                <Button
+                  variant='text'
+                  size='xSmall'
+                  onClick={() => {
+                    console.log('columnsData: ', columnsData);
+                    console.log('hiddenColumns: ', hiddenColumns);
+                    // onColumnsVisibilityChange(HideColumnsEnum.All);
+                  }}
+                >
+                  <Icon name='eye-show-outline' color='#1473e6' />
+                  <Text size={12} tint={100}>
+                    {HideColumnsEnum.ShowMetrics}
+                  </Text>
+                </Button>
+
+                <Button
+                  variant='text'
+                  size='xSmall'
+                  onClick={() => {
+                    console.log('columnsData: ', columnsData);
+                    console.log('hiddenColumns: ', hiddenColumns);
+                    // onColumnsVisibilityChange(HideColumnsEnum.All);
+                  }}
+                >
+                  <Icon name='eye-outline-hide' />
+                  <Text size={12} tint={100}>
+                    {HideColumnsEnum.HideMetrics}
+                  </Text>
+                </Button>
                 <Button
                   variant='text'
                   size='xSmall'

--- a/src/src/types/services/models/model.d.ts
+++ b/src/src/types/services/models/model.d.ts
@@ -15,6 +15,7 @@ export interface State {
   params?: Record<string, any>;
   sameValueColumns?: string[];
   selectedRows?: any;
+  sortOptions?: Record<string, any>;
   tooltip?: ITooltip;
   selectFormData?: any;
 }

--- a/src/src/utils/app/onColumnsVisibilityChange.ts
+++ b/src/src/utils/app/onColumnsVisibilityChange.ts
@@ -67,6 +67,18 @@ export default function onColumnsVisibilityChange<M extends State>({
           return false;
         });
         break;
+      case HideColumnsEnum.HideMetrics:
+        const metrics = modelState.sortOptions?.filter(
+          (option: ISelectOption) => {
+            return option.group === 'metrics';
+          },
+        );
+        // Set columnkeys to all metrics plus the already hidden columns from config.table.hiddencolumns
+        columnKeys = _.uniq([
+          ...configData?.table.hiddenColumns,
+          ...metrics.map((metric: ISelectOption) => metric.label),
+        ]);
+        break;
     }
     const table = {
       ...configData.table,

--- a/src/src/utils/app/onColumnsVisibilityChange.ts
+++ b/src/src/utils/app/onColumnsVisibilityChange.ts
@@ -99,6 +99,16 @@ export default function onColumnsVisibilityChange<M extends State>({
           ...params.map((param: ISelectOption) => param.label.split('.')[1]),
         ]);
         break;
+      case HideColumnsEnum.ShowParams:
+        params = modelState.sortOptions?.filter((option: any) => {
+          return option.group === 'run' && option.value?.includes('params');
+        });
+        columnKeys = configData?.table.hiddenColumns.filter((col: string) => {
+          return !params.some(
+            (param: ISelectOption) => param.label.split('.')[1] === col,
+          );
+        });
+        break;
     }
     const table = {
       ...configData.table,

--- a/src/src/utils/app/onColumnsVisibilityChange.ts
+++ b/src/src/utils/app/onColumnsVisibilityChange.ts
@@ -90,6 +90,15 @@ export default function onColumnsVisibilityChange<M extends State>({
           );
         });
         break;
+      case HideColumnsEnum.HideParams:
+        params = modelState.sortOptions?.filter((option: any) => {
+          return option.group === 'run' && option.value?.includes('params');
+        });
+        columnKeys = _.uniq([
+          ...configData?.table.hiddenColumns,
+          ...params.map((param: ISelectOption) => param.label.split('.')[1]),
+        ]);
+        break;
     }
     const table = {
       ...configData.table,

--- a/src/src/utils/app/onColumnsVisibilityChange.ts
+++ b/src/src/utils/app/onColumnsVisibilityChange.ts
@@ -7,7 +7,10 @@ import { AVOID_COLUMNS_TO_HIDE_LIST } from 'config/table/tableConfigs';
 import * as analytics from 'services/analytics';
 
 import { IModel, State } from 'types/services/models/model';
-import { IAppModelConfig } from 'types/services/models/explorer/createAppModel';
+import {
+  IAppModelConfig,
+  ISelectOption,
+} from 'types/services/models/explorer/createAppModel';
 import { ITableColumn } from 'types/pages/metrics/components/TableColumns/TableColumns';
 
 import { encode } from 'utils/encoder/encoder';
@@ -30,11 +33,14 @@ export default function onColumnsVisibilityChange<M extends State>({
     shouldURLUpdate?: boolean,
   ) => void;
 }): void {
-  const configData = model.getState()?.config;
-  const columnsData = model.getState()!.tableColumns!;
+  const modelState = model.getState();
+  const configData = modelState?.config;
+  const columnsData = modelState!.tableColumns!;
   const systemMetrics: string[] = getSystemMetricsFromColumns(
     columnsData as ITableColumn[],
   );
+  let params: ISelectOption[] = [];
+  let metrics: ISelectOption[] = [];
 
   let columnKeys: string[] = Array.isArray(hiddenColumns)
     ? [...hiddenColumns]
@@ -68,16 +74,21 @@ export default function onColumnsVisibilityChange<M extends State>({
         });
         break;
       case HideColumnsEnum.HideMetrics:
-        const metrics = modelState.sortOptions?.filter(
-          (option: ISelectOption) => {
-            return option.group === 'metrics';
-          },
-        );
+        metrics = modelState.sortOptions?.filter((option: ISelectOption) => {
+          return option.group === 'metrics';
+        });
         // Set columnkeys to all metrics plus the already hidden columns from config.table.hiddencolumns
         columnKeys = _.uniq([
           ...configData?.table.hiddenColumns,
           ...metrics.map((metric: ISelectOption) => metric.label),
         ]);
+        break;
+      case HideColumnsEnum.ShowMetrics:
+        columnKeys = configData?.table.hiddenColumns.filter((col: string) => {
+          return !modelState.sortOptions?.some(
+            (option: ISelectOption) => option.label === col,
+          );
+        });
         break;
     }
     const table = {

--- a/src/src/utils/app/onColumnsVisibilityChange.ts
+++ b/src/src/utils/app/onColumnsVisibilityChange.ts
@@ -58,13 +58,16 @@ export default function onColumnsVisibilityChange<M extends State>({
       hideSystemMetrics =
         getFilteredSystemMetrics(columnKeys).length === systemMetrics.length;
     }
-    columnKeys =
-      hiddenColumns === HideColumnsEnum.All
-        ? columnsData.map(
-            (col) => !AVOID_COLUMNS_TO_HIDE_LIST.has(col.key) && col.key,
-          )
-        : columnKeys;
-
+    switch (hiddenColumns) {
+      case HideColumnsEnum.All:
+        columnKeys = columnsData.map((col) => {
+          if (!AVOID_COLUMNS_TO_HIDE_LIST.has(col.key)) {
+            return col.label ?? col.key;
+          }
+          return false;
+        });
+        break;
+    }
     const table = {
       ...configData.table,
       hiddenColumns: columnKeys,


### PR DESCRIPTION
PR for https://github.com/G-Research/fasttrackml/issues/76.

Note that there was an issue with the Hide All button which wasn't working correctly with lots (5000+) of metrics, and also there were some pretty terrible performance issue when pressing any of the triggers.

This PR aims to fix the Hide All logic, as well as patching some of the performance issues (reduces wait times from around 60 seconds down to 2-3 seconds when pressing any trigger, at the cost of not being able to view/search columns correctly when there are 100+ columns). Users are expected to use the Toggle buttons or automatically hiding unselected metrics/params to begin with.

### Changelog
- Fix Hide All logic (wasn't filtering custom metrics)
- Add virtualization for middle column to fix performance issues
  - Only active when there are >100 columns in the list
  - BUG: Virtualization doesn't let you view all the columns
  - BUG: (CSS issue) Dragging items makes the item visually disappear (it shifts from view becoming invisible, but the logic works as intended)
- Add toggles for Metrics and Params
  - Show/Hide All Params
  - Show/Hide All Metrics